### PR TITLE
Rename Encoder classes

### DIFF
--- a/demos/encoder/main.cc
+++ b/demos/encoder/main.cc
@@ -21,12 +21,11 @@
 #include "usbconfig.h"
 #include "printf.h"
 
-#include "encoder.h"
-#include "foawencoder.h"
+#include "encoderfoaw.h"
 
 namespace {
     const systime_t loop_time = MS2ST(100); /* loop at 10 Hz */
-    using encoder_t = FoawEncoder<float, 16>;
+    using encoder_t = EncoderFoaw<float, 16>;
     encoder_t encoder(&GPTD5, /* CH1, CH2 connected to PA0, PA1 and NOT enabled by board.h */
             {PAL_NOLINE, /* no index channel */
              152000, /* counts per revolution */

--- a/demos/encoder_hots/main.cc
+++ b/demos/encoder_hots/main.cc
@@ -21,11 +21,11 @@
 #include "usbconfig.h"
 #include "printf.h"
 
-#include "tsencoder.h"
+#include "encoderhots.h"
 
 namespace {
     const systime_t loop_time = MS2ST(100); /* loop at 10 Hz */
-    using encoder_t = TSEncoder<2, 16, 0>;
+    using encoder_t = EncoderHots<2, 16, 0>;
     encoder_t encoder({
             LINE_TIM5_CH1,
             LINE_TIM5_CH2,

--- a/inc/encoderfoaw.h
+++ b/inc/encoderfoaw.h
@@ -4,10 +4,10 @@
 #include "ch.h"
 
 template <typename T, size_t N>
-class FoawEncoder: public Encoder {
+class EncoderFoaw: public Encoder {
     public:
         // TODO: GPT for higher sampling frequency instead of virtual timer?
-        FoawEncoder(GPTDriver* gptp, const EncoderConfig& config,
+        EncoderFoaw(GPTDriver* gptp, const EncoderConfig& config,
                     systime_t sample_period, T allowed_error);
         virtual void start() override;
         virtual void stop() override;
@@ -21,4 +21,4 @@ class FoawEncoder: public Encoder {
         static void sample_callback(void* p);
 };
 
-#include "foawencoder.hh"
+#include "encoderfoaw.hh"

--- a/inc/encoderhots.h
+++ b/inc/encoderhots.h
@@ -13,10 +13,10 @@
  * Note: The delay option has not been implemented.
  */
 
-using tsenccnt_t = int32_t;
+using hotscnt_t = int32_t;
 using polycoeff_t = float;
 
-struct TSEncoderConfig {
+struct EncoderHotsConfig {
     /*
      * GPIO for encoder channels A, B, Z should be set in board.h.
      * ioline_t a; IO line for encoder A channel
@@ -32,11 +32,11 @@ struct TSEncoderConfig {
     ioline_t a; /* IO line for encoder A channel */
     ioline_t b; /* IO line for encoder B channel */
     ioline_t z; /* IO line for encoder Z channel or PAL_NOLINE if not used */
-    tsenccnt_t counts_per_rev; /* encoder counts per revolution */
+    hotscnt_t counts_per_rev; /* encoder counts per revolution */
 };
 
 template <size_t M, size_t N, size_t O>
-class TSEncoder {
+class EncoderHots {
     public:
         static constexpr unsigned int m = M; /* polynomial order */
         static constexpr unsigned int n = N; /* encoder event buffer length */
@@ -50,7 +50,7 @@ class TSEncoder {
             NONE, NOTFOUND, FOUND
         };
 
-        TSEncoder(const TSEncoderConfig& config);
+        EncoderHots(const EncoderHotsConfig& config);
         void start();
         void stop();
         state_t state() const;
@@ -62,18 +62,18 @@ class TSEncoder {
         polycoeff_t acceleration() const;
 
     private:
-        using event_t = std::pair<rtcnt_t, tsenccnt_t>;
+        using event_t = std::pair<rtcnt_t, hotscnt_t>;
         mutable std::array<event_t, N> m_events; /* circular buffer for encoder events */
         mutable size_t m_event_index; /* index of oldest entry */
         mutable size_t m_skip_order_counter; /* skip order counter */
         Eigen::Matrix<polycoeff_t, N, M + 1> m_A; /* time stamp matrix */
         Eigen::Matrix<polycoeff_t, M + 1, 1> m_P; /* polynomial coefficients */
-        Eigen::Matrix<tsenccnt_t, N, 1> m_B; /* position vector */
+        Eigen::Matrix<hotscnt_t, N, 1> m_B; /* position vector */
         Eigen::Matrix<polycoeff_t, M + 1, 1> m_T; /* time vector */
         rtcnt_t m_t0; /* polynomial zero time */
         polycoeff_t m_alpha; /* time scaling factor */
-        const TSEncoderConfig m_config;
-        tsenccnt_t m_count; /* encoder count */
+        const EncoderHotsConfig m_config;
+        hotscnt_t m_count; /* encoder count */
         rtcnt_t m_tc; /* estimate time */
         state_t m_state;
         index_t m_index;
@@ -83,8 +83,8 @@ class TSEncoder {
         static void ab_callback(EXTDriver* extp, expchannel_t channel);
         static void index_callback(EXTDriver* extp, expchannel_t channel);
         static void add_event_callback(void* p);
-        void add_event(rtcnt_t t, tsenccnt_t x, bool use_skip) const;
+        void add_event(rtcnt_t t, hotscnt_t x, bool use_skip) const;
         void add_deadline_event() const;
 };
 
-#include "tsencoder.hh"
+#include "encoderhots.hh"

--- a/src/encoderfoaw.hh
+++ b/src/encoderfoaw.hh
@@ -1,9 +1,9 @@
 /*
- * Member function definitions of FoawEncoder template class.
+ * Member function definitions of EncoderFoaw template class.
  * See foawencoder.h for template class declaration.
  */
 template <typename T, size_t N>
-FoawEncoder<T, N>::FoawEncoder(GPTDriver* gptp, const EncoderConfig& config,
+EncoderFoaw<T, N>::EncoderFoaw(GPTDriver* gptp, const EncoderConfig& config,
                                systime_t sample_period, T allowed_error) :
 Encoder(gptp, config),
 m_estimator(static_cast<T>(1.0)/sample_period, allowed_error),
@@ -12,25 +12,25 @@ m_sample_period(sample_period) {
 }
 
 template <typename T, size_t N>
-void FoawEncoder<T, N>::start() {
+void EncoderFoaw<T, N>::start() {
     Encoder::start();
     chVTSet(&m_sample_timer, m_sample_period, sample_callback, static_cast<void*>(this));
 }
 
 template <typename T, size_t N>
-void FoawEncoder<T, N>::stop() {
+void EncoderFoaw<T, N>::stop() {
     chVTReset(&m_sample_timer);
     Encoder::stop();
 }
 
 template <typename T, size_t N>
-T FoawEncoder<T, N>::velocity() const {
+T EncoderFoaw<T, N>::velocity() const {
     return m_estimator.estimate_velocity();
 }
 
 template <typename T, size_t N>
-void FoawEncoder<T, N>::sample_callback(void* p) {
-    FoawEncoder<T, N>* enc = static_cast<FoawEncoder<T, N>*>(p);
+void EncoderFoaw<T, N>::sample_callback(void* p) {
+    EncoderFoaw<T, N>* enc = static_cast<EncoderFoaw<T, N>*>(p);
     enc->m_estimator.add_position(static_cast<T>(enc->count()));
     chVTSet(&enc->m_sample_timer, enc->m_sample_period, sample_callback, p);
 }


### PR DESCRIPTION
Standardize encoder naming by placing algorithm acronym as a suffix and
avoiding all uppercase.