### PR TITLE
Define EncoderFoaw::velocity() as a const member function

### DIFF
--- a/inc/encoderfoaw.h
+++ b/inc/encoderfoaw.h
@@ -11,10 +11,10 @@ class EncoderFoaw: public Encoder {
                     systime_t sample_period, T allowed_error);
         virtual void start() override;
         virtual void stop() override;
-        T velocity();
+        T velocity() const;
 
     private:
-        IQHandler<T, 4, N> m_iqhandler;
+        mutable IQHandler<T, 4, N> m_iqhandler;
         virtual_timer_t m_sample_timer;
         const systime_t m_timer_period; /* sample period in system ticks */
         const T m_sample_period; /* converted from input, stored in seconds */

--- a/src/encoderfoaw.hh
+++ b/src/encoderfoaw.hh
@@ -32,7 +32,7 @@ void EncoderFoaw<T, N>::stop() {
 }
 
 template <typename T, size_t N>
-T EncoderFoaw<T, N>::velocity() {
+T EncoderFoaw<T, N>::velocity() const {
     m_iqhandler.wait();
     T vel = foaw::estimate_velocity(m_iqhandler.circular_buffer(),
             m_iqhandler.index(), m_sample_period, m_allowed_error);


### PR DESCRIPTION
While velocity() requires member variables in EncoderFoaw to be mutable,
the method is marked const as only the internal fields of the class are
modified.