### PR TITLE
Fix rear wheel angle and forward velocity calculations

### DIFF
--- a/projects/inc/saconfig.h
+++ b/projects/inc/saconfig.h
@@ -19,16 +19,17 @@ constexpr EncoderConfig RLS_ROLIN_ENC_INDEX_CFG = {
     .filter = EncoderConfig::filter_t::CAPTURE_64 /* 64 / 42 MHz (TIM5 on APB1) = 1.52 us for valid edge */
 };
 
+
+constexpr float REAR_WHEEL_RADIUS = 0.66f; /* m */
+constexpr float ROLLER_TO_REAR_WHEEL_RATIO = 1.0f/6; /* rear wheel radius = 6 * roller radius */
+
 constexpr GPTDriver* RLS_GTS35_ENC = &GPTD3;
 
 constexpr EncoderConfig RLS_GTS35_ENC_CFG = {
     .z = PAL_NOLINE, /* no index channel */
-    .counts_per_rev = 48,
+    .counts_per_rev = 48 * 4 * 6,
     .filter = EncoderConfig::filter_t::CAPTURE_256 /* 256 / 42 MHz (TIM3 on APB1) = 6.09 us for valid edge */
 };
-
-constexpr float REAR_WHEEL_RADIUS = 0.66f; /* m */
-constexpr float ROLLER_TO_REAR_WHEEL_RATIO = 1.0f/6; /* rear wheel radius = 6 * roller radius */
 
 constexpr float MAX_KISTLER_TORQUE = 50.0f; /* maximum measured steer torque, N-m */
 


### PR DESCRIPTION
Include the roller to rear wheel ratio in RLS_GTS35_ENC_CFG to give the
encoder count for the rear wheel directly. Increase counts per
revolution by 4x as 48 is the number of slots and not equal to counts
when the encoder is used in quadrature.

Forward velocity v is positive for negative rear wheel angular velocity
and is redefined accordingly.