### PR TITLE
Handle position overflow in FOAH velocity estimation

### DIFF
--- a/inc/foaw.h
+++ b/inc/foaw.h
@@ -20,7 +20,8 @@ namespace foaw {
 
 template <typename T, size_t N>
 T estimate_velocity(const std::array<T, N>& circular_buffer,
-        size_t oldest_index, T sample_period, T allowed_error);
+        size_t oldest_index, T sample_period, T allowed_error,
+        T overflow_value=static_cast<T>(0));
 
 } // namespace foaw
 

--- a/src/encoderfoaw.hh
+++ b/src/encoderfoaw.hh
@@ -35,7 +35,8 @@ template <typename T, size_t N>
 T EncoderFoaw<T, N>::velocity() const {
     m_iqhandler.wait();
     T vel = foaw::estimate_velocity(m_iqhandler.circular_buffer(),
-            m_iqhandler.index(), m_sample_period, m_allowed_error);
+            m_iqhandler.index(), m_sample_period, m_allowed_error,
+            static_cast<T>(config().counts_per_rev));
     m_iqhandler.signal();
     return vel;
 }


### PR DESCRIPTION
Add new argument 'overflow_value' to foah::estimate_velocity() with
default value of 0. This argument represents a positive value with would
cause the underlying data to overflow; this commonly occurs with
encoders. If positive, the position buffer elements will be modified in
place if overflow or underflow is detected during the velocity
estimation calculation. The buffer elements will be restored at the end.