### PR TITLE
Limit pitch constraint iterations

### DIFF
--- a/projects/src/simplebicycle.cc
+++ b/projects/src/simplebicycle.cc
@@ -57,7 +57,7 @@ void SimpleBicycle::update(real_t roll_torque_input, real_t steer_torque_input,
     update_state(steer_angle_measurement);
     m_x_aux = integrate_auxiliary_state(m_x, m_x_aux);
     m_x_aux[auxiliary_state_index_t::pitch_angle] =
-        solve_constraint_pitch(m_x, m_x_aux[auxiliary_state_index_t::pitch_angle]);
+        solve_constraint_pitch(m_x, m_x_aux[auxiliary_state_index_t::pitch_angle], 3);
     update_feedback_torque();
 
     set_pose();
@@ -136,7 +136,7 @@ real_t SimpleBicycle::solve_constraint_pitch(const state_t& x, real_t guess, siz
     if (iteration_limit > 0) {
         max_iterations = iteration_limit;
     } else {
-        // use a "reasonable" default number of this case
+        // use a "reasonable" default number in this case
         max_iterations = 7;
     }
 

--- a/projects/src/simplebicycle.cc
+++ b/projects/src/simplebicycle.cc
@@ -130,7 +130,7 @@ real_t SimpleBicycle::solve_constraint_pitch(const state_t& x, real_t guess, siz
     static constexpr real_t two = static_cast<real_t>(2.0);
     static constexpr real_t one_point_five = static_cast<real_t>(1.5);
     static const real_t min = static_cast<real_t>(0.0);
-    static const real_t max = constants::pi/2;
+    static const real_t max = constants::pi/4;
     boost::uintmax_t max_iterations;
 
     if (iteration_limit > 0) {


### PR DESCRIPTION
Limit Newton-Raphson iterations when solving for pitch angle constraint
to 3. In normal cases, the pitch angle can be solved in 1 to 2
constraints. It is only in extreme/unrealistic configurations where the
number of iterations increases, but these do not result in realistic
pitch values, so there is no reason to expend computation time.