### PR TITLE
Use measured steer assembly inertia

### DIFF
--- a/projects/inc/saconfig.h
+++ b/projects/inc/saconfig.h
@@ -50,7 +50,9 @@ constexpr DACConfig dac1cfg1 = {
 };
 constexpr const DACConfig* KOLLM_DAC_CFG = &dac1cfg1;
 
-// TODO: measure the real value
-constexpr float STEER_ASSEMBLY_INERTIA = 0.1f; /* moment of inertia of steering assembly about the steer axis, kg-m^2 */
+/* moment of inertia of steering assembly about the steer axis, kg-m^2 */
+constexpr float STEER_ASSEMBLY_INERTIA_WITH_WEIGHT = 0.1942f; /* with 1 kg weight plate on each side of cross bar*/
+constexpr float STEER_ASSEMBLY_INERTIA_WITHOUT_WEIGHT = 0.0828f; /* without weight plates */
+constexpr float STEER_ASSEMBLY_INERTIA = STEER_ASSEMBLY_INERTIA_WITH_WEIGHT; /* default configuration */
 
 } // namespace


### PR DESCRIPTION
Define steer assembly inertia about the steering axis for configurations
with and without weight plates based on experimental data. Use steer
assembly inertia with weight plates as default.

Data and calculation are available here:
https://drive.google.com/drive/folders/0B0TYqj2SzQN5MWx6eU04cmVHMnc?usp=sharing