### PR TITLE
:sparkles: Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# http://editorconfig.org/
+
+root = true
+
+[{CMakeLists.txt,*.{c,cc,h,hh,py}{,.in}}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
The .editorconfig serves as a cross-editor configuration, assuming your editor
has an editorconfig plugin installed and enabled.