### PR TITLE
Disable roll angle saturation

### DIFF
--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -48,7 +48,6 @@ class Bicycle {
         static constexpr real_t default_v = 5.0; /* forward speed, m/s */
         static constexpr real_t default_steer_inertia = sa::STEER_ASSEMBLY_INERTIA; /* kg-m^2 */
         static constexpr real_t v_quantization_resolution = 0.1; /* m/s */
-        static constexpr real_t roll_angle_limit = 60.0 * constants::as_radians; /* 60 deg in rad */
         static constexpr real_t roll_rate_limit = 1e10; /* rad */
         static constexpr real_t steer_rate_limit = 1e10; /* rad */
 

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -108,20 +108,8 @@ void Bicycle<T, U, V>::update_dynamics(real_t roll_torque_input, real_t steer_to
             roll_angle += std::copysign(constants::two_pi, -1*roll_angle);
         }
 
-        if (!(std::is_same<T, model::BicycleKinematic>::value) &&
-            (std::abs(roll_angle) > roll_angle_limit)) {
-            model_t::set_state_element(x, model_t::state_index_t::roll_angle,
-                    std::copysign(roll_angle_limit, roll_angle));
-            model_t::set_state_element(x, model_t::state_index_t::steer_angle,
-                    steer_angle_measurement);
-            model_t::set_state_element(x, model_t::state_index_t::roll_rate,
-                    model_t::get_full_state_element(state_full, full_state_index_t::roll_rate));
-            model_t::set_state_element(x, model_t::state_index_t::steer_rate,
-                    model_t::get_full_state_element(state_full, full_state_index_t::steer_rate));
-        } else {
-            limit_state_element(model_t::state_index_t::roll_rate, roll_rate_limit);
-            limit_state_element(model_t::state_index_t::steer_rate, steer_rate_limit);
-        }
+        limit_state_element(model_t::state_index_t::roll_rate, roll_rate_limit);
+        limit_state_element(model_t::state_index_t::steer_rate, steer_rate_limit);
 
         m_observer.set_state(x);
     }


### PR DESCRIPTION
Remove roll angle limit when not using the BicycleKinematic model. Rate
saturation is retained.