### PR TITLE
WIP Fix motor torque calculation

### DIFF
--- a/inc/analog.h
+++ b/inc/analog.h
@@ -2,6 +2,10 @@
 #include "hal.h"
 #include <array>
 
+constexpr eventflags_t adc_eventflag_complete = EVENT_MASK(0);
+constexpr eventflags_t adc_eventflag_error = EVENT_MASK(1);
+extern event_source_t adc_event_source;
+
 class Analog {
     public:
         Analog();

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -63,6 +63,7 @@ namespace {
                                               sa::RLS_GTS35_ENC_CFG,
                                               MS2ST(1), 3.0f);
     filter::MovingAverage<float, 5> velocity_filter;
+    filter::MovingAverage<float, 5> kistler_filter;
 
     constexpr float fixed_velocity = 5.0f;
 
@@ -264,8 +265,9 @@ int main(void) {
 
         // get sensor measurements
 #if !defined(FLIMNAP_ZERO_INPUT)
-        const float kistler_torque = adc_to_nm(analog.get_adc12(),
-                sa::KISTLER_ADC_ZERO_OFFSET, sa::MAX_KISTLER_TORQUE);
+        const float kistler_torque = kistler_filter.output(
+                adc_to_nm(analog.get_adc12(),
+                    sa::KISTLER_ADC_ZERO_OFFSET, sa::MAX_KISTLER_TORQUE));
 #endif // !defined(FLIMNAP_ZERO_INPUT)
         const float motor_torque = adc_to_nm(analog.get_adc13(),
                 sa::KOLLMORGEN_ADC_ZERO_OFFSET, sa::MAX_KOLLMORGEN_TORQUE);

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -127,7 +127,7 @@ namespace {
             typename S::observer_t& observer = bicycle.observer();
             observer.set_Q(parameters::defaultvalue::kalman::Q(observer.dt()));
             // Reduce steer measurement noise covariance
-            observer.set_R(parameters::defaultvalue::kalman::R/10);
+            observer.set_R(parameters::defaultvalue::kalman::R/1000);
 
             // prime the Kalman gain matrix
             bicycle.prime_observer();

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -296,7 +296,8 @@ int main(void) {
         bicycle.update_dynamics(roll_torque, steer_torque, yaw_angle, steer_angle, rear_wheel_angle);
 
         // generate handlebar torque output
-        const dacsample_t handlebar_torque_dac = set_handlebar_torque(bicycle.handlebar_feedback_torque());
+        const float feedback_torque = bicycle.handlebar_feedback_torque() - kistler_torque;
+        const dacsample_t handlebar_torque_dac = set_handlebar_torque(feedback_torque);
         chTMStopMeasurementX(&computation_time_measurement);
 
         // prepare message for transmission
@@ -317,7 +318,7 @@ int main(void) {
                 encoder_steer.count(), encoder_rear_wheel.count());
         message::set_simulation_timing(&msg,
                 computation_time_measurement.last, transmission_time_measurement.last);
-        msg.feedback_torque = bicycle.handlebar_feedback_torque();
+        msg.feedback_torque = feedback_torque;
         msg.has_feedback_torque = true;
         size_t bytes_written = write_message_to_encode_buffer(msg);
 

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -231,7 +231,7 @@ int main(void) {
     // Initialize HandlebarDynamic object to estimate torque due to handlebar inertia.
     // TODO: naming here is poor
 #if !defined(FLIMNAP_ZERO_INPUT)
-    haptic::HandlebarDynamic handlebar_model(bicycle.model(), sa::HANDLEBAR_INERTIA);
+    haptic::HandlebarDynamic handlebar_model(bicycle.model(), sa::UPPER_ASSEMBLY_INERTIA_VIRTUAL);
 #endif  // !defined(FLIMNAP_ZERO_INPUT)
 
     observer_initializer<observer_t> oi;

--- a/projects/inc/haptic.h
+++ b/projects/inc/haptic.h
@@ -55,6 +55,7 @@ class HandlebarDynamic final : public HandlebarBase {
         virtual model::real_t torque(
                 const model::Bicycle::state_t& x,
                 const model::Bicycle::input_t& u = model::Bicycle::input_t::Zero()) const override;
+        model::real_t moment_of_inertia() const;
 
     private:
         model::Bicycle& m_bicycle;

--- a/projects/inc/haptic.h
+++ b/projects/inc/haptic.h
@@ -12,7 +12,7 @@ namespace haptic {
 
 class HandlebarBase {
     public:
-        virtual model::real_t feedback_torque(
+        virtual model::real_t torque(
                 const model::Bicycle::state_t& x, const model::Bicycle::input_t& u) const = 0;
 
     protected:
@@ -23,7 +23,7 @@ class null_t final : public HandlebarBase {
     public:
         null_t(model::Bicycle& bicycle);
         null_t(model::Bicycle& bicycle, model::real_t moment_of_inertia);
-        virtual model::real_t feedback_torque(
+        virtual model::real_t torque(
                 const model::Bicycle::state_t& x,
                 const model::Bicycle::input_t& u = model::Bicycle::input_t::Zero()) const override;
 };
@@ -37,7 +37,7 @@ class HandlebarStatic final : public HandlebarBase {
     public:
         HandlebarStatic(model::Bicycle& bicycle);
         HandlebarStatic(model::Bicycle& bicycle, model::real_t moment_of_inertia);
-        virtual model::real_t feedback_torque(
+        virtual model::real_t torque(
                 const model::Bicycle::state_t& x,
                 const model::Bicycle::input_t& u = model::Bicycle::input_t::Zero()) const override;
 
@@ -52,7 +52,7 @@ class HandlebarStatic final : public HandlebarBase {
 class HandlebarDynamic final : public HandlebarBase {
     public:
         HandlebarDynamic(model::Bicycle& bicycle, model::real_t moment_of_inertia);
-        virtual model::real_t feedback_torque(
+        virtual model::real_t torque(
                 const model::Bicycle::state_t& x,
                 const model::Bicycle::input_t& u = model::Bicycle::input_t::Zero()) const override;
 

--- a/projects/inc/saconfig.h
+++ b/projects/inc/saconfig.h
@@ -53,13 +53,19 @@ constexpr DACConfig dac1cfg1 = {
 };
 constexpr const DACConfig* KOLLM_DAC_CFG = &dac1cfg1;
 
-/* Moment of inertia of steering assembly about the steer axis, kg-m^2 */
-constexpr float STEER_ASSEMBLY_INERTIA_WITH_WEIGHT = 0.1942f; // with 1 kg weight plate on each side of cross bar
-constexpr float STEER_ASSEMBLY_INERTIA_WITHOUT_WEIGHT = 0.0828f; // without weight plates
-constexpr float STEER_ASSEMBLY_INERTIA = STEER_ASSEMBLY_INERTIA_WITH_WEIGHT; // default configuration
+/*
+ * Moment of inertia of full steering assembly about the steer axis, kg-m^2
+ */
+constexpr float FULL_ASSEMBLY_INERTIA_WITH_WEIGHT = 0.1942f; // with 1 kg weight plate on each side of cross bar
+constexpr float FULL_ASSEMBLY_INERTIA_WITHOUT_WEIGHT = 0.0828f; // without weight plates
+constexpr float FULL_ASSEMBLY_INERTIA = FULL_ASSEMBLY_INERTIA_WITH_WEIGHT; // default configuration
 
-/* Moment of inertia of the handlebars and steering column above the torque sensor, about the steer axis 
- * determined from scripts/calculate_handlebar_inertia.py */
-constexpr float HANDLEBAR_INERTIA = 0.1314; // kg-m^2
-
+/*
+ * For the moment of inertia of the upper assembly, we use both virtual and physical values.
+ * See ICSC2017 abstract for details.
+ * The virtual term is determined from scripts/calculate_handlebar_inertia.py
+ * The physical term is determined from an experiment measuring the oscillation period.
+ */
+constexpr float UPPER_ASSEMBLY_INERTIA_VIRTUAL = 0.1314; // kg-m^2
+constexpr float UPPER_ASSEMBLY_INERTIA_PHYSICAL = 0.0413; // kg-m^2
 } // namespace

--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -55,7 +55,7 @@ class Bicycle {
         Bicycle(real_t v = default_v, real_t dt = default_dt,
                 real_t upper_assembly_inertia_virtual = sa::UPPER_ASSEMBLY_INERTIA_VIRTUAL,
                 real_t lower_assembly_inertia_physical = (sa::FULL_ASSEMBLY_INERTIA -
-                                                          sa::UPPER_ASSEMBLY_INERTIA_PHYSICAL));
+                                                          sa::UPPER_ASSEMBLY_INERTIA_VIRTUAL));
 
         void set_v(real_t v);
         void set_dt(real_t dt);

--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -55,7 +55,7 @@ class Bicycle {
         Bicycle(real_t v = default_v, real_t dt = default_dt,
                 real_t upper_assembly_inertia_virtual = sa::UPPER_ASSEMBLY_INERTIA_VIRTUAL,
                 real_t lower_assembly_inertia_physical = (sa::FULL_ASSEMBLY_INERTIA -
-                                                          sa::UPPER_ASSEMBLY_INERTIA_VIRTUAL));
+                                                          sa::UPPER_ASSEMBLY_INERTIA_PHYSICAL));
 
         void set_v(real_t v);
         void set_dt(real_t dt);

--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -80,6 +80,8 @@ class Bicycle {
         const model_t& model() const;
         observer_t& observer();
         const observer_t& observer() const;
+        const haptic_t& inertia_upper_virtual() const;
+        const haptic_t& inertia_lower_physical() const;
         const second_order_matrix_t& M() const;
         const second_order_matrix_t& C1() const;
         const second_order_matrix_t& K0() const;

--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -47,7 +47,8 @@ class Bicycle {
         static constexpr real_t default_fs = 200.0; // sample rate, Hz
         static constexpr real_t default_dt = 1.0/default_fs; // sample period, s
         static constexpr real_t default_v = 5.0; // forward speed, m/s
-        static constexpr real_t default_steer_inertia = sa::FULL_ASSEMBLY_INERTIA; // kg-m^2
+        static constexpr real_t default_steer_inertia =
+            sa::FULL_ASSEMBLY_INERTIA - sa::UPPER_ASSEMBLY_INERTIA_PHYSICAL; // kg-m^2
         static constexpr real_t v_quantization_resolution = 0.1; // m/s
         static constexpr real_t roll_rate_limit = 1e10; // rad
         static constexpr real_t steer_rate_limit = 1e10; // rad

--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -47,7 +47,7 @@ class Bicycle {
         static constexpr real_t default_fs = 200.0; // sample rate, Hz
         static constexpr real_t default_dt = 1.0/default_fs; // sample period, s
         static constexpr real_t default_v = 5.0; // forward speed, m/s
-        static constexpr real_t default_steer_inertia = sa::STEER_ASSEMBLY_INERTIA; // kg-m^2
+        static constexpr real_t default_steer_inertia = sa::FULL_ASSEMBLY_INERTIA; // kg-m^2
         static constexpr real_t v_quantization_resolution = 0.1; // m/s
         static constexpr real_t roll_rate_limit = 1e10; // rad
         static constexpr real_t steer_rate_limit = 1e10; // rad

--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -74,6 +74,7 @@ class Bicycle {
 
         const BicyclePoseMessage& pose() const; // get most recently computed pose
         real_t handlebar_feedback_torque() const; // get most recently computed feedback torque
+        const input_t& input() const; // get most recently computed input
 
         // common bicycle model member variables
         model_t& model();
@@ -102,6 +103,7 @@ class Bicycle {
         haptic_t m_inertia_lower_physical; // handlebar feedback calculation object
         full_state_t m_state_full; // auxiliary + dynamic state
         BicyclePoseMessage m_pose; // Unity visualization message
+        input_t m_input; // bicycle model input vector
         binary_semaphore_t m_state_sem; // bsem for synchronizing kinematics update
         real_t m_T_m; // handlebar feedback torque
 };

--- a/projects/src/haptic.cc
+++ b/projects/src/haptic.cc
@@ -99,4 +99,7 @@ model::real_t HandlebarDynamic::torque(const model::Bicycle::state_t& x, const m
     return steer_acceleration*m_I_delta - model::Bicycle::get_input_element(u, model::Bicycle::input_index_t::steer_torque);
 }
 
+model::real_t HandlebarDynamic::moment_of_inertia() const {
+    return m_I_delta;
+}
 } //namespace haptic

--- a/projects/src/haptic.cc
+++ b/projects/src/haptic.cc
@@ -14,7 +14,7 @@ null_t::null_t(model::Bicycle& bicycle, model::real_t moment_of_inertia) {
     (void)moment_of_inertia;
 }
 
-model::real_t null_t::feedback_torque(const model::Bicycle::state_t& x, const model::Bicycle::input_t& u) const {
+model::real_t null_t::torque(const model::Bicycle::state_t& x, const model::Bicycle::input_t& u) const {
     (void)x;
     (void)u;
     return 0;
@@ -47,7 +47,7 @@ HandlebarStatic::HandlebarStatic(model::Bicycle& bicycle, model::real_t moment_o
  * In this case, delta_dd is set to zero as well to simplify calculations resulting in:
  *      T_m = -T_delta
  */
-model::real_t HandlebarStatic::feedback_torque(const model::Bicycle::state_t& x, const model::Bicycle::input_t& u) const {
+model::real_t HandlebarStatic::torque(const model::Bicycle::state_t& x, const model::Bicycle::input_t& u) const {
     (void)u;
     const model::real_t v = m_bicycle.v();
     const model::Bicycle::second_order_matrix_t K = constants::g*m_bicycle.K0() + v*v*m_bicycle.K2();
@@ -90,7 +90,7 @@ HandlebarDynamic::HandlebarDynamic(model::Bicycle& bicycle, model::real_t moment
  * state or noise in the input. For use with equipment, it is suggested to
  * filter the returned value.
  */
-model::real_t HandlebarDynamic::feedback_torque(const model::Bicycle::state_t& x, const model::Bicycle::input_t& u) const {
+model::real_t HandlebarDynamic::torque(const model::Bicycle::state_t& x, const model::Bicycle::input_t& u) const {
     static constexpr auto steer_rate_index =
         static_cast<typename std::underlying_type<model::Bicycle::state_index_t>::type>(
                 model::Bicycle::state_index_t::steer_rate);

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -76,7 +76,7 @@ void Bicycle<Model, Observer, Haptic>::update_dynamics(real_t roll_torque_measur
     measurement_t measurement = measurement_t::Zero();
 
     // Convert roll, steer torque from physical to virtual.
-    const float upper_inertia_torque = m_inertia_upper_virtual.feedback_torque(m_observer.state());
+    const float upper_inertia_torque = m_inertia_upper_virtual.torque(m_observer.state());
     // steer_torque_measurement sign is correct when considering the lower assembly but needs
     // to be flipped when considering the upper assembly.
     const float steer_torque = steer_torque_measurement + upper_inertia_torque;
@@ -120,7 +120,7 @@ void Bicycle<Model, Observer, Haptic>::update_dynamics(real_t roll_torque_measur
         m_observer.set_state(x);
     }
 
-    m_T_m = m_inertia_lower_physical.feedback_torque(m_observer.state(), input) - steer_torque_measurement;
+    m_T_m = m_inertia_lower_physical.torque(m_observer.state(), input) - steer_torque_measurement;
 
     // Merge observer and model states
     //

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -12,10 +12,13 @@
 namespace sim {
 
 template <typename Model, typename Observer, typename Haptic>
-Bicycle<Model, Observer, Haptic>::Bicycle(real_t v, real_t dt, real_t steer_inertia) :
+Bicycle<Model, Observer, Haptic>::Bicycle(real_t v, real_t dt,
+        real_t upper_assembly_inertia_virtual,
+        real_t lower_assembly_inertia_physical) :
 m_model(v, dt),
 m_observer(m_model),
-m_haptic(m_model, steer_inertia),
+m_inertia_upper_virtual(m_model, upper_assembly_inertia_virtual),
+m_inertia_lower_physical(m_model, lower_assembly_inertia_physical),
 m_state_full(full_state_t::Zero()),
 m_pose(BicyclePoseMessage_init_zero) {
     // Note: User must initialize Kalman matrices in application.
@@ -56,26 +59,31 @@ void Bicycle<Model, Observer, Haptic>::reset() {
 }
 
 template <typename Model, typename Observer, typename Haptic>
-void Bicycle<Model, Observer, Haptic>::update_dynamics(real_t roll_torque_input, real_t steer_torque_input,
-    real_t yaw_angle_measurement,
-    real_t steer_angle_measurement,
-    real_t rear_wheel_angle_measurement) {
-
-    //  While the rear wheel angle measurement can be used to determine velocity,
-    //  it is assumed that velocity is determined outside this class and passed as
-    //  an input. This allows the velocity resolution, and thus the model update
-    //  frequency, to be determined by a filter unrelated to the bicycle model.
+void Bicycle<Model, Observer, Haptic>::update_dynamics(real_t roll_torque_measurement,
+        real_t steer_torque_measurement, real_t yaw_angle_measurement,
+        real_t steer_angle_measurement, real_t rear_wheel_angle_measurement) {
+    // While the rear wheel angle measurement can be used to determine velocity,
+    // it is assumed that velocity is determined outside this class and passed as
+    // an input. This allows the velocity resolution, and thus the model update
+    // frequency, to be determined by a filter unrelated to the bicycle model.
     //
-    //  This could also be used to determine the wheel angles, as we assume
-    //  no-slip conditions. However, we calculate the wheel angles during the
-    //  kinematic  update and solely from bicycle velocity.
-    (void)rear_wheel_angle_measurement;
+    // The rear wheel angle measurement also could be used to determine the
+    // wheel angles. Instead we assume no-slip conditions and calculate the wheel
+    // angle during the kinematic update and solely from bicycle velocity.
+    (void)rear_wheel_angle_measurement; // velocity is calculated and updated externally
 
     input_t input = input_t::Zero();
     measurement_t measurement = measurement_t::Zero();
 
-    model_t::set_input_element(input, model_t::input_index_t::roll_torque, roll_torque_input);
-    model_t::set_input_element(input, model_t::input_index_t::steer_torque, steer_torque_input);
+    // Convert roll, steer torque from physical to virtual.
+    const float upper_inertia_torque = m_inertia_upper_virtual.feedback_torque(m_observer.state());
+    // steer_torque_measurement sign is correct when considering the lower assembly but needs
+    // to be flipped when considering the upper assembly.
+    const float steer_torque = steer_torque_measurement + upper_inertia_torque;
+    const float roll_torque = roll_torque_measurement;
+
+    model_t::set_input_element(input, model_t::input_index_t::roll_torque, roll_torque);
+    model_t::set_input_element(input, model_t::input_index_t::steer_torque, steer_torque);
     model_t::set_output_element(measurement, model_t::output_index_t::yaw_angle, yaw_angle_measurement);
     model_t::set_output_element(measurement, model_t::output_index_t::steer_angle, steer_angle_measurement);
 
@@ -112,7 +120,7 @@ void Bicycle<Model, Observer, Haptic>::update_dynamics(real_t roll_torque_input,
         m_observer.set_state(x);
     }
 
-    m_T_m = m_haptic.feedback_torque(m_observer.state(), input);
+    m_T_m = m_inertia_lower_physical.feedback_torque(m_observer.state(), input) - steer_torque_measurement;
 
     // Merge observer and model states
     //
@@ -136,7 +144,7 @@ void Bicycle<Model, Observer, Haptic>::update_kinematics() {
     full_state_t x = m_state_full;
     chBSemSignal(&m_state_sem);
 
-    // solve for pitch as this does not get integrated
+    // solve for pitch as this does not calculated by integration in update_dynamics()
     const real_t roll = model_t::get_full_state_element(x, full_state_index_t::roll_angle);
     const real_t steer = model_t::get_full_state_element(x, full_state_index_t::steer_angle);
     real_t pitch = model_t::get_full_state_element(x, full_state_index_t::pitch_angle);

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -20,7 +20,8 @@ m_observer(m_model),
 m_inertia_upper_virtual(m_model, upper_assembly_inertia_virtual),
 m_inertia_lower_physical(m_model, lower_assembly_inertia_physical),
 m_state_full(full_state_t::Zero()),
-m_pose(BicyclePoseMessage_init_zero) {
+m_pose(BicyclePoseMessage_init_zero),
+m_input(input_t::Zero()) {
     // Note: User must initialize Kalman matrices in application.
     // TODO: Do this automatically with default values?
     chBSemObjectInit(&m_state_sem, false); // initialize to not taken

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -120,6 +120,7 @@ void Bicycle<Model, Observer, Haptic>::update_dynamics(real_t roll_torque_measur
         m_observer.set_state(x);
     }
 
+    m_input = input;
     m_T_m = m_inertia_lower_physical.torque(m_observer.state(), input) - steer_torque_measurement;
 
     // Merge observer and model states
@@ -189,6 +190,11 @@ const BicyclePoseMessage& Bicycle<Model, Observer, Haptic>::pose() const {
 template <typename Model, typename Observer, typename Haptic>
 model::real_t Bicycle<Model, Observer, Haptic>::handlebar_feedback_torque() const {
     return m_T_m;
+}
+
+template <typename Model, typename Observer, typename Haptic>
+const typename Bicycle<Model, Observer, Haptic>::input_t& Bicycle<Model, Observer, Haptic>::input() const {
+    return m_input;
 }
 
 template <typename Model, typename Observer, typename Haptic>

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -212,6 +212,16 @@ const typename Bicycle<Model, Observer, Haptic>::observer_t& Bicycle<Model, Obse
 };
 
 template <typename Model, typename Observer, typename Haptic>
+const typename Bicycle<Model, Observer, Haptic>::haptic_t& Bicycle<Model, Observer, Haptic>::inertia_upper_virtual() const {
+    return m_inertia_upper_virtual;
+};
+
+template <typename Model, typename Observer, typename Haptic>
+const typename Bicycle<Model, Observer, Haptic>::haptic_t& Bicycle<Model, Observer, Haptic>::inertia_lower_physical() const {
+    return m_inertia_lower_physical;
+};
+
+template <typename Model, typename Observer, typename Haptic>
 const typename Bicycle<Model, Observer, Haptic>::second_order_matrix_t& Bicycle<Model, Observer, Haptic>::M() const {
     return m_model.M();
 }

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -79,7 +79,7 @@ void Bicycle<Model, Observer, Haptic>::update_dynamics(real_t roll_torque_measur
     const float upper_inertia_torque = m_inertia_upper_virtual.torque(m_observer.state());
     // steer_torque_measurement sign is correct when considering the lower assembly but needs
     // to be flipped when considering the upper assembly.
-    const float steer_torque = steer_torque_measurement + upper_inertia_torque;
+    const float steer_torque = upper_inertia_torque + steer_torque_measurement;
     const float roll_torque = roll_torque_measurement;
 
     model_t::set_input_element(input, model_t::input_index_t::roll_torque, roll_torque);
@@ -121,7 +121,7 @@ void Bicycle<Model, Observer, Haptic>::update_dynamics(real_t roll_torque_measur
     }
 
     m_input = input;
-    m_T_m = m_inertia_lower_physical.torque(m_observer.state(), input) - steer_torque_measurement;
+    m_T_m = m_inertia_lower_physical.torque(m_observer.state(), input) + steer_torque_measurement;
 
     // Merge observer and model states
     //

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -121,7 +121,8 @@ void Bicycle<Model, Observer, Haptic>::update_dynamics(real_t roll_torque_measur
     }
 
     m_input = input;
-    m_T_m = m_inertia_lower_physical.torque(m_observer.state(), input) + steer_torque_measurement;
+    //m_T_m = m_inertia_lower_physical.torque(m_observer.state(), input) + steer_torque_measurement;
+    m_T_m = 3.1816*m_inertia_lower_physical.torque(m_observer.state(), input) + steer_torque_measurement;
 
     // Merge observer and model states
     //

--- a/scripts/icsc2017/generate_figures.py
+++ b/scripts/icsc2017/generate_figures.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     # plot in degrees because understanding radians is harder
     states = records.state[:, 1:] * 180/np.pi
     fig1, ax1 = plot_states(t, states, second_yaxis=True,
-                            convert_to_degrees=False)
+                            to_degrees=False)
 
     m = messages[0]
     v = m.model.v
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     x = simulate(v, x0, dt, n)
     t = np.array(range(n + 1)) * dt
     fig2, ax2 = plot_states(t, np.hstack((x0, x)).T, second_yaxis=True,
-                            convert_to_degrees=True)
+                            to_degrees=True)
 
     # set the axes x limits to be the same
     ax1[0].set_xlim([0, 3])

--- a/scripts/plot_sim.py
+++ b/scripts/plot_sim.py
@@ -157,10 +157,10 @@ if __name__ == '__main__':
     ax3.plot(t, records.input[:, 1], label='steer torque', color=STATE_COLOR[3])
     ax3.plot(t, inertia_torque, label='handlebar inertia torque',
              color=STATE_COLOR[1])
-    ax3.plot(t, inertia_torque + bits_to_Nm(
-                        records.sensors.kistler_measured_torque, 50),
-            label='calculated virtual steer torque',
-            color=STATE_COLOR[7])
+    #ax3.plot(t, inertia_torque + bits_to_Nm(
+    #                    records.sensors.kistler_measured_torque, 50),
+    #        label='calculated virtual steer torque',
+    #        color=STATE_COLOR[7])
     ax3.set_ylabel('torque [N-m]')
     ax3.set_xlabel('time [s]')
     ax3.legend()

--- a/scripts/plot_sim.py
+++ b/scripts/plot_sim.py
@@ -28,7 +28,7 @@ def handlebar_inertia_torque(records, A):
     A_delta_dd = A[4, :]
     state = records.state
     steer_accel = np.dot(A_delta_dd, state.T)
-    inertia_torque = sa.HANDLEBAR_INERTIA * steer_accel
+    inertia_torque = sa.UPPER_ASSEMBLY_INERTIA_VIRTUAL * steer_accel
     return inertia_torque, steer_accel
 
 

--- a/scripts/plot_sim.py
+++ b/scripts/plot_sim.py
@@ -32,9 +32,9 @@ def handlebar_inertia_torque(records, A):
     return inertia_torque, steer_accel
 
 
-def plot_states(t, states, second_yaxis=False, convert_to_degrees=True):
+def plot_states(t, states, second_yaxis=False, to_degrees=True):
     # plot in degrees
-    if convert_to_degrees:
+    if to_degrees:
         states *= 180/np.pi
 
     fig, ax1 = plt.subplots()
@@ -115,8 +115,7 @@ if __name__ == '__main__':
 
     # plot in degrees
     states = records.state[:, 1:] * 180/np.pi
-    fig1, ax1 = plot_states(t, states, second_yaxis=False,
-                            convert_to_degrees=False)
+    fig1, ax1 = plot_states(t, states, second_yaxis=False, to_degrees=False)
 
     encoder_count = records.sensors.steer_encoder_count
     encoder_angle = encoder_count / 152000 * 360

--- a/scripts/plot_sim.py
+++ b/scripts/plot_sim.py
@@ -157,6 +157,10 @@ if __name__ == '__main__':
     ax3.plot(t, records.input[:, 1], label='steer torque', color=STATE_COLOR[3])
     ax3.plot(t, inertia_torque, label='handlebar inertia torque',
              color=STATE_COLOR[1])
+    ax3.plot(t, inertia_torque + bits_to_Nm(
+                        records.sensors.kistler_measured_torque, 50),
+            label='calculated virtual steer torque',
+            color=STATE_COLOR[7])
     ax3.set_ylabel('torque [N-m]')
     ax3.set_xlabel('time [s]')
     ax3.legend()

--- a/scripts/simulate_whipple_benchmark.py
+++ b/scripts/simulate_whipple_benchmark.py
@@ -43,22 +43,26 @@ if __name__ == '__main__':
     import matplotlib.pyplot as plt
     from plot_sim import plot_states
 
-    sim_time = 5 # time for our Whipple simulation [s]
+    sim_time = 1 # time for our Whipple simulation or upper limit [s]
 
     if len(sys.argv) > 1:
         from load_sim import (load_messages, get_records_from_messages,
                               get_time_vector)
         messages = load_messages(sys.argv[1])
         records = get_records_from_messages(messages)
-        t = get_time_vector(records)
+        t = get_time_vector(records[1:]) # skip first record
         t -= t[0] # redefine zero time for simulator data
-        m = messages[0]
-        states = records.state[:, 1:]
-        fig2, ax2 = plot_states(t, states)
 
+        m = messages[0]
         v = m.model.v
         dt = m.model.dt
+        if t[-1] < sim_time:
+            sim_time = t[-1]
         n = int(sim_time/dt)
+
+        states = records[1:].state[:, 1:]
+        fig2, ax2 = plot_states(t[:n], states[:n, :], to_degrees=True)
+        fig2.suptitle('Phobos simulator')
         x0 = np.array(messages[1].state.x[1:]).reshape((4, 1))
     else:
         v = 5
@@ -70,5 +74,7 @@ if __name__ == '__main__':
 
     x = simulate(v, x0, dt, n)
     t = np.array(range(n + 1)) * dt
-    fig, ax = plot_states(t, np.hstack((x0, x)).T)
+    fig, ax = plot_states(t, np.hstack((x0, x)).T, to_degrees=True)
+    fig.suptitle('Whipple simulation')
+
     plt.show()

--- a/src/analog.cc
+++ b/src/analog.cc
@@ -25,11 +25,9 @@
  * TODO: move functions from unnamed namespace to private static methods
  */
 
-namespace {
-    const eventflags_t adc_eventflag_complete = EVENT_MASK(0);
-    const eventflags_t adc_eventflag_error = EVENT_MASK(1);
-    event_source_t adc_event_source;
+event_source_t adc_event_source;
 
+namespace {
     void adcerrorcallback(ADCDriver* adcp, adcerror_t err) {
         (void)adcp;
         (void)err;


### PR DESCRIPTION
This is a poor way to implement the correct calculation. We need to track across two classes what terms have been calculated and which have not. However, I'm not sure there if there is a better way to implement this. Some other options are to:
~~1. Pass the measured sensor torque to `sim::Bicycle`. This would allow the motor torque calculation to be done entirely in `sim::Bicycle`. However, the steer torque input is calculated in the project file.~~
~~2. Get the steer acceleration from `sim::Bicycle` and do the motor calculation in the project file. This would keep all `physical` terms outside of the `sim::Bicycle` class.~~
3.  Move the handlebar model into `sim::Bicycle` and do 1.

And this certainly needs some hardware tests before merging.

Fixes #109 

- [x] merge #119
- [ ] fix and build and test with hardware