### PR TITLE
Test clang builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,21 @@ addons:
     sources:
       - george-edison55-precise-backports # cmake 3.2.3
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.9
       - git-core
     packages:
       - cmake
       - cmake-data
       - g++-6
+      - clang-3.9
       - git
 
 env:
-  - BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug -DCHIBIOS_USE_LTO=0"
-  - BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug -DCHIBIOS_USE_LTO=1"
-  - BUILD_TYPE="-DCMAKE_BUILD_TYPE=Release -DCHIBIOS_USE_LTO=1"
+  - BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug -DCHIBIOS_USE_LTO=0 -DPHOBOS_BUILD_DEMOS=1 -DPHOBOS_BUILD_PROJECTS=1 -DPHOBOS_BUILD_TOOLS=0 -DPHOBOS_BUILD_TESTS=0"
+  - BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug -DCHIBIOS_USE_LTO=1 -DPHOBOS_BUILD_DEMOS=1 -DPHOBOS_BUILD_PROJECTS=1 -DPHOBOS_BUILD_TOOLS=0 -DPHOBOS_BUILD_TESTS=0"
+  - BUILD_TYPE="-DCMAKE_BUILD_TYPE=Release -DCHIBIOS_USE_LTO=1 -DPHOBOS_BUILD_DEMOS=1 -DPHOBOS_BUILD_PROJECTS=1 -DPHOBOS_BUILD_TOOLS=0 -DPHOBOS_BUILD_TESTS=0"
+  - BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug -DPHOBOS_BUILD_DEMOS=0 -DPHOBOS_BUILD_PROJECTS=0 -DPHOBOS_BUILD_TOOLS=1 -DPHOBOS_BUILD_TESTS=1" CC_COMPILER="gcc-6" CXX_COMPILER="g++-6"
+  - BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug -DPHOBOS_BUILD_DEMOS=0 -DPHOBOS_BUILD_PROJECTS=0 -DPHOBOS_BUILD_TOOLS=1 -DPHOBOS_BUILD_TESTS=1" CC_COMPILER="clang-3.9" CXX_COMPILER="clang++-3.9"
 
 install:
   - bash travis/install-toolchain.sh
@@ -43,7 +47,7 @@ install:
   - ls $HOME/protobuf
   - bash travis/checkout-submodules.sh
   - ls $HOME/submodules
-  - export CXX="g++-6" CC="gcc-6"
+  - export CXX=$CXX_COMPILER CC=$CC_COMPILER
 
 script:
   - mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,17 @@ endmacro(add_phobos_executable target_name)
 
 include_directories(inc)
 include_directories(src) # definitions for template classes are placed in src directory
-
 add_subdirectory(src)
-add_subdirectory(demos)
-add_subdirectory(projects)
+
+option(PHOBOS_BUILD_DEMOS "Build embedded demos" TRUE)
+if(PHOBOS_BUILD_DEMOS)
+    add_subdirectory(demos)
+endif()
+
+option(PHOBOS_BUILD_PROJECTS "Build embedded projects" TRUE)
+if(PHOBOS_BUILD_PROJECTS)
+    add_subdirectory(projects)
+endif()
 
 option(PHOBOS_BUILD_TOOLS "Build various tools" TRUE)
 if(PHOBOS_BUILD_TOOLS)
@@ -130,4 +137,9 @@ if(PHOBOS_BUILD_TOOLS)
         INSTALL_COMMAND "")
     set_directory_properties(PROPERTY
         ADDITIONAL_MAKE_CLEAN_FILES ${PROJECT_BINARY_DIR}/tools)
+endif()
+
+option(PHOBOS_BUILD_TESTS "Build host machine tests" TRUE)
+if(PHOBOS_BUILD_TESTS)
+    #add_subdirectory(tests) # this hasn't been added yet
 endif()


### PR DESCRIPTION
Change Travis to run five build environments, three compiling embedded
code and two for host code. Build host tools and tests with gcc and
clang.

Fixes #110 