### PR TITLE
Split Flimnap CMake build option

### DIFF
--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -69,8 +69,11 @@ if(PHOBOS_BUILD_PROJECT_DRUNLO)
     add_subdirectory(drunlo)
 endif()
 
-option(PHOBOS_BUILD_PROJECT_FLIMNAP "Build Flimnap (static simulator) demo" TRUE)
-if(PHOBOS_BUILD_PROJECT_FLIMNAP)
+option(PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE
+    "Build Flimnap (static simulator) demo using the Whipple bicycle model" TRUE)
+option(PHOBOS_BUILD_PROJECT_FLIMNAP_KINEMATIC
+    "Build Flimnap (static simulator) demo using the kinematic bicycle model" TRUE)
+if(PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE OR PHOBOS_BUILD_PROJECT_FLIMNAP_KINEMATIC)
     add_subdirectory(flimnap)
 endif()
 

--- a/projects/flimnap/CMakeLists.txt
+++ b/projects/flimnap/CMakeLists.txt
@@ -30,7 +30,11 @@ set(FLIMNAP_COMMON_SRC
     ${PROTOBUF_GENERATED_SOURCE}
     ${BICYCLE_SOURCE})
 
+if(PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE)
 add_phobos_executable(flimnap_whipple ${FLIMNAP_COMMON_SRC})
+endif()
+if(PHOBOS_BUILD_PROJECT_FLIMNAP_KINEMATIC)
 add_phobos_executable(flimnap_kinematic ${FLIMNAP_COMMON_SRC})
 target_compile_definitions(flimnap_kinematic
     PRIVATE USE_BICYCLE_KINEMATIC_MODEL)
+endif()


### PR DESCRIPTION
Replace CMake build option PHOBOS_BUILD_PROJECT_FLIMNAP with the two
options PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE and
PHOBOS_BUILD_PROJECT_FLIMNAP_KINEMATIC allowing use of either model.
This allows a specific version to be built and used with CMake openocd
options.