### PR TITLE
Update system physical constants after reassembly

### DIFF
--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -73,7 +73,11 @@ option(PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE
     "Build Flimnap (static simulator) demo using the Whipple bicycle model" TRUE)
 option(PHOBOS_BUILD_PROJECT_FLIMNAP_KINEMATIC
     "Build Flimnap (static simulator) demo using the kinematic bicycle model" TRUE)
-if(PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE OR PHOBOS_BUILD_PROJECT_FLIMNAP_KINEMATIC)
+option(PHOBOS_BUILD_PROJECT_FLIMNAP_ZERO_INPUT
+    "Build Flimnap (static simulator) demo using the Whipple bicycle model with input fixed to zero" TRUE)
+if(PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE OR
+   PHOBOS_BUILD_PROJECT_FLIMNAP_KINEMATIC OR
+   PHOBOS_BUILD_PROJECT_FLIMNAP_ZERO_INPUT)
     add_subdirectory(flimnap)
 endif()
 

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -77,12 +77,12 @@ if(PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE OR PHOBOS_BUILD_PROJECT_FLIMNAP_KINEMATI
     add_subdirectory(flimnap)
 endif()
 
-option(PHOBOS_BUILD_PROJECT_GULLIVER "Build New (static simulator) demo" TRUE)
+option(PHOBOS_BUILD_PROJECT_GULLIVER "Build Gulliver (static simulator) demo" TRUE)
 if(PHOBOS_BUILD_PROJECT_GULLIVER)
     add_subdirectory(gulliver)
 endif()
 
-option(PHOBOS_BUILD_PROJECT_HALL "Build New (static simulator) demo" TRUE)
+option(PHOBOS_BUILD_PROJECT_HALL "Build Hall (static simulator) demo" TRUE)
 if(PHOBOS_BUILD_PROJECT_HALL)
     add_subdirectory(hall)
 endif()

--- a/projects/flimnap/CMakeLists.txt
+++ b/projects/flimnap/CMakeLists.txt
@@ -38,3 +38,8 @@ add_phobos_executable(flimnap_kinematic ${FLIMNAP_COMMON_SRC})
 target_compile_definitions(flimnap_kinematic
     PRIVATE USE_BICYCLE_KINEMATIC_MODEL)
 endif()
+if(PHOBOS_BUILD_PROJECT_FLIMNAP_ZERO_INPUT)
+add_phobos_executable(flimnap_zero_input ${FLIMNAP_COMMON_SRC})
+target_compile_definitions(flimnap_zero_input
+    PRIVATE FLIMNAP_ZERO_INPUT)
+endif()

--- a/projects/inc/saconfig.h
+++ b/projects/inc/saconfig.h
@@ -18,7 +18,7 @@ constexpr EncoderConfig RLS_ROLIN_ENC_INDEX_CFG = {
     .z = PAL_LINE(GPIOA, GPIOA_PIN2),
     .counts_per_rev = 152000,
     .filter = EncoderConfig::filter_t::CAPTURE_64, /* 64 / 42 MHz (TIM5 on APB1) = 1.52 us for valid edge */
-    .z_count = 18536
+    .z_count = 20926
 };
 
 

--- a/projects/inc/saconfig.h
+++ b/projects/inc/saconfig.h
@@ -8,40 +8,40 @@ namespace sa {
 constexpr GPTDriver* RLS_ROLIN_ENC = &GPTD5;
 
 constexpr EncoderConfig RLS_ROLIN_ENC_CFG = {
-    .z = PAL_NOLINE, /* no index channel */
+    .z = PAL_NOLINE, // no index channel
     .counts_per_rev = 152000,
-    .filter = EncoderConfig::filter_t::CAPTURE_64, /* 64 / 42 MHz (TIM5 on APB1) = 1.52 us for valid edge */
+    .filter = EncoderConfig::filter_t::CAPTURE_64, // 64 / 42 MHz (TIM5 on APB1) = 1.52 us for valid edge
     .z_count = 0
 };
 
 constexpr EncoderConfig RLS_ROLIN_ENC_INDEX_CFG = {
     .z = PAL_LINE(GPIOA, GPIOA_PIN2),
     .counts_per_rev = 152000,
-    .filter = EncoderConfig::filter_t::CAPTURE_64, /* 64 / 42 MHz (TIM5 on APB1) = 1.52 us for valid edge */
+    .filter = EncoderConfig::filter_t::CAPTURE_64, // 64 / 42 MHz (TIM5 on APB1) = 1.52 us for valid edge
     .z_count = 20926
 };
 
 
-constexpr float REAR_WHEEL_RADIUS = 0.3f; /* m */
-constexpr float ROLLER_TO_REAR_WHEEL_RATIO = 1.0f/6; /* rear wheel radius = 6 * roller radius */
+constexpr float REAR_WHEEL_RADIUS = 0.3f; // m
+constexpr float ROLLER_TO_REAR_WHEEL_RATIO = 1.0f/6; // rear wheel radius = 6 * roller radius
 
 constexpr GPTDriver* RLS_GTS35_ENC = &GPTD3;
 
 constexpr EncoderConfig RLS_GTS35_ENC_CFG = {
-    .z = PAL_NOLINE, /* no index channel */
+    .z = PAL_NOLINE, // no index channel
     .counts_per_rev = 48 * 4 * 6,
-    .filter = EncoderConfig::filter_t::CAPTURE_256, /* 256 / 42 MHz (TIM3 on APB1) = 6.09 us for valid edge */
+    .filter = EncoderConfig::filter_t::CAPTURE_256, // 256 / 42 MHz (TIM3 on APB1) = 6.09 us for valid edge
     .z_count = 0
 };
 
-constexpr float MAX_KISTLER_TORQUE = 50.0f; /* maximum measured steer torque, N-m */
+constexpr float MAX_KISTLER_TORQUE = 50.0f; // maximum measured steer torque, N-m
 
 /*
  * The voltage output of the Kistler torque sensor is ±10V. With the 12-bit ADC,
  * resolution for LSB is 4.88 mV/bit or 12.2 mNm/bit.
  */
-constexpr float MAX_KOLLMORGEN_TORQUE = 10.78f; /* max torque at 1.00 Arms/V, N-m */
-constexpr dacsample_t KOLLMORGEN_DAC_ZERO_OFFSET = 2048 - 155; /* DAC value for zero torque, found experimentally */
+constexpr float MAX_KOLLMORGEN_TORQUE = 10.78f; // max torque at 1.00 Arms/V, N-m
+constexpr dacsample_t KOLLMORGEN_DAC_ZERO_OFFSET = 2048 - 155; // DAC value for zero torque, found experimentally
 
 constexpr DACDriver* KOLLM_DAC = &DACD1;
 
@@ -51,12 +51,12 @@ constexpr DACConfig dac1cfg1 = {
 };
 constexpr const DACConfig* KOLLM_DAC_CFG = &dac1cfg1;
 
-/* moment of inertia of steering assembly about the steer axis, kg-m^2 */
-constexpr float STEER_ASSEMBLY_INERTIA_WITH_WEIGHT = 0.1942f; /* with 1 kg weight plate on each side of cross bar*/
-constexpr float STEER_ASSEMBLY_INERTIA_WITHOUT_WEIGHT = 0.0828f; /* without weight plates */
-constexpr float STEER_ASSEMBLY_INERTIA = STEER_ASSEMBLY_INERTIA_WITH_WEIGHT; /* default configuration */
+/* Moment of inertia of steering assembly about the steer axis, kg-m^2 */
+constexpr float STEER_ASSEMBLY_INERTIA_WITH_WEIGHT = 0.1942f; // with 1 kg weight plate on each side of cross bar
+constexpr float STEER_ASSEMBLY_INERTIA_WITHOUT_WEIGHT = 0.0828f; // without weight plates
+constexpr float STEER_ASSEMBLY_INERTIA = STEER_ASSEMBLY_INERTIA_WITH_WEIGHT; // default configuration
 
-/* moment of inertia of the handlebars and steering column above the torque sensor, about the steer axis 
+/* Moment of inertia of the handlebars and steering column above the torque sensor, about the steer axis 
  * determined from scripts/calculate_handlebar_inertia.py */
 constexpr float HANDLEBAR_INERTIA = 0.1384; // kg-m^2
 

--- a/projects/inc/saconfig.h
+++ b/projects/inc/saconfig.h
@@ -41,7 +41,7 @@ constexpr float MAX_KISTLER_TORQUE = 50.0f; /* maximum measured steer torque, N-
  * resolution for LSB is 4.88 mV/bit or 12.2 mNm/bit.
  */
 constexpr float MAX_KOLLMORGEN_TORQUE = 10.78f; /* max torque at 1.00 Arms/V, N-m */
-constexpr dacsample_t KOLLMORGEN_DAC_ZERO_OFFSET = 2048 - 125; /* DAC value for zero torque, found experimentally */
+constexpr dacsample_t KOLLMORGEN_DAC_ZERO_OFFSET = 2048 - 155; /* DAC value for zero torque, found experimentally */
 
 constexpr DACDriver* KOLLM_DAC = &DACD1;
 

--- a/projects/inc/saconfig.h
+++ b/projects/inc/saconfig.h
@@ -58,6 +58,6 @@ constexpr float STEER_ASSEMBLY_INERTIA = STEER_ASSEMBLY_INERTIA_WITH_WEIGHT; /* 
 
 /* moment of inertia of the handlebars and steering column above the torque sensor, about the steer axis 
  * determined from scripts/calculate_handlebar_inertia.py */
-constexpr float HANDLEBAR_INERTIA = 0.118; /* kg-m^2 */
+constexpr float HANDLEBAR_INERTIA = 0.1384; // kg-m^2
 
 } // namespace

--- a/scripts/plot_sim.py
+++ b/scripts/plot_sim.py
@@ -9,7 +9,7 @@ import seaborn as sns
 from load_sim import load_messages, get_records_from_messages, get_time_vector
 
 MAX_KOLLMORGEN_TORQUE = 10.78
-KOLLMORGEN_DAC_ZERO_OFFSET = 2048 - 125
+KOLLMORGEN_DAC_ZERO_OFFSET = 2048 - 155
 HANDLEBAR_INERTIA = 0.11889455460271312
 
 STATE_LABELS = ['roll angle', 'steer angle', 'roll rate', 'steer rate']


### PR DESCRIPTION
Steer encoder index position and upper assembly virtual inertia need to be updated after the steering assembly was disassembled and reassembled.
- [x] update encoder index position
- [x] add project for determining virtual inertia
- [x] update upper assembly virtual inertia
- [x] merge #118 