### PR TITLE
Change meaning of COBS result object fields

### DIFF
--- a/inc/cobs.h
+++ b/inc/cobs.h
@@ -15,7 +15,12 @@ namespace cobs {
             WRITE_OVERFLOW
         };
         const Status status;
-        const size_t written;
+
+        /**
+        If the status is OK, the number of bytes that were written to dst_start.
+        Otherwise it is set to 0.
+        */
+        const size_t produced;
     };
 
     EncodeResult encode(const uint8_t * const src_start, size_t src_len, uint8_t * const dst_start, size_t dst_len);
@@ -28,8 +33,18 @@ namespace cobs {
             UNEXPECTED_ZERO
         };
         const Status status;
-        const size_t read;
-        const size_t written;
+
+        /**
+        If the status is OK, the number of bytes that were written to dst_start.
+        Otherwise it is set to 0.
+        */
+        const size_t consumed;
+
+        /**
+        If the status is OK or UNEXPECTED_ZERO, the number of bytes that were
+        read from src_start. Otherwise it is set to 0.
+        */
+        const size_t produced;
     };
 
     DecodeResult decode(const uint8_t * const src_start, size_t src_len, uint8_t * const dst_start, size_t dst_len);

--- a/src/cobs.cc
+++ b/src/cobs.cc
@@ -126,7 +126,7 @@ namespace cobs {
 
         auto bytes_produced = [&dst_copy, &dst_start]() -> size_t {
             // Can cast because dst_copy >= dst_start.
-            return (size_t) (dst_copy - dst_start);
+            return static_cast<size_t> (dst_copy - dst_start);
         };
 
         auto create_ok_status = [&bytes_produced]() -> EncodeResult {
@@ -184,12 +184,12 @@ namespace cobs {
 
         auto bytes_consumed = [&src, &src_start]() -> size_t {
             // Can cast because src >= src_start.
-            return (size_t) (src - src_start);
+            return static_cast<size_t> (src - src_start);
         };
 
         auto bytes_produced = [&dst, &dst_start]() -> size_t {
             // Can cast because dst >= dst_start.
-            return (size_t) (dst - dst_start);
+            return static_cast<size_t> (dst - dst_start);
         };
 
         auto create_ok_status = [&bytes_consumed, &bytes_produced]() -> DecodeResult {

--- a/tests/test_cobs.cc
+++ b/tests/test_cobs.cc
@@ -59,14 +59,14 @@ void test_encode_decode(std::vector<Rep> decoded, std::vector<Rep> encoded) {
     // Encode.
     const cobs::EncodeResult enc_act_res = cobs::encode(dec_exp, dec_exp_len, enc_act, sizeof(enc_act));
     EXPECT_EQ(enc_act_res.status, cobs::EncodeResult::Status::OK);
-    EXPECT_EQ(enc_act_res.written, enc_exp_len);
+    EXPECT_EQ(enc_act_res.produced, enc_exp_len);
     test_equal_buffers(enc_exp, sizeof(enc_exp), enc_act, sizeof(enc_act));
 
     // Decode.
     const cobs::DecodeResult dec_act_res = cobs::decode(enc_exp, enc_exp_len, dec_act, sizeof(dec_act));
     EXPECT_EQ(dec_act_res.status, cobs::DecodeResult::Status::OK);
-    EXPECT_EQ(dec_act_res.read, enc_exp_len);
-    EXPECT_EQ(dec_act_res.written, dec_exp_len);
+    EXPECT_EQ(dec_act_res.consumed, enc_exp_len);
+    EXPECT_EQ(dec_act_res.produced, dec_exp_len);
     test_equal_buffers(dec_exp, sizeof(dec_exp), dec_act, sizeof(dec_act));
 }
 

--- a/tests/test_cobs_random.cc
+++ b/tests/test_cobs_random.cc
@@ -46,13 +46,13 @@ void CobsRandomDataTest::test_encode_decode() {
     // encode b1 to b2
     const cobs::EncodeResult enc_res = cobs::encode(b1.data(), b1.size(), b2.data(), b2.capacity());
     ASSERT_EQ(enc_res.status, cobs::EncodeResult::Status::OK);
-    b2.resize(enc_res.written);
+    b2.resize(enc_res.produced);
 
     // decode b2 to b3
     const cobs::DecodeResult dec_res = cobs::decode(b2.data(), b2.size(), b3.data(), b3.capacity());
     ASSERT_EQ(dec_res.status, cobs::DecodeResult::Status::OK);
-    ASSERT_EQ(dec_res.read, b2.size());
-    b3.resize(dec_res.written);
+    ASSERT_EQ(dec_res.consumed, b2.size());
+    b3.resize(dec_res.produced);
 
     // test b1 == b3
     test_equal_buffers(b1.data(), b1.size(), b3.data(), b3.size());


### PR DESCRIPTION
EncodeResult.written becomes EncodeResult.produced. Its value is only useful
when the status is OK so in other cases it is set to 0.

DecodeResult.read becomes DecodeResult.consumed. Its value is only useful
when the status is OK or UNEXPECTED_ZERO so in other cases it is set to 0. This
makes things slightly easier for code calling `cobs::decode`.

DecodeResult.written becomes DecodeResult.produced. Its value is only useful
when the status is OK so in other cases it is set to 0.