### PR TITLE
WIP Add assistive roll torque to bicycle simulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ set(NANOPB_SRC_ROOT_FOLDER ${PROJECT_SOURCE_DIR}/external/nanopb)
 include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFSPEC GITSHA1)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
 
 ## Define macro for phobos project executable
 # This macro adds common sources for all targets in this project and
@@ -72,6 +72,8 @@ macro(add_phobos_executable target_name)
             if(USE_BICYCLE_EIGEN3_SUBMODULE)
                 set_property(SOURCE ${src} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-deprecated")
             endif()
+            # suppress ChibiOS usb serial warning
+            set_property(SOURCE ${src} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-maybe-uninitialized")
             math(EXPR source_file_properties_modified
                 "${source_file_properties_modified} + 1")
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ macro(add_phobos_executable target_name)
     if(USE_BICYCLE_BOOST_SUBMODULE)
         # suppress boost undef warnings
         set_property(SOURCE ${BICYCLE_SOURCE} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef")
+        set_property(SOURCE ${ARGN} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-misleading-indentation")
     endif()
     if(USE_BICYCLE_EIGEN3_SUBMODULE)
         # Any request from Eigen to allocate memory from heap results in an assertion failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,6 @@ macro(add_phobos_executable target_name)
             if(USE_BICYCLE_EIGEN3_SUBMODULE)
                 set_property(SOURCE ${src} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-deprecated")
             endif()
-            # suppress ChibiOS usb serial warning
-            set_property(SOURCE ${src} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-maybe-uninitialized")
             math(EXPR source_file_properties_modified
                 "${source_file_properties_modified} + 1")
         endif()
@@ -91,9 +89,9 @@ macro(add_phobos_executable target_name)
             math(EXPR source_file_properties_modified
                 "${source_file_properties_modified} + 1")
         endif()
-        if(source_file_properties_modified GREATER 2)
-            break()
-        endif()
+        #if(source_file_properties_modified GREATER 2)
+        #    break()
+        #endif()
     endforeach()
 
     if(USE_BICYCLE_BOOST_SUBMODULE)

--- a/projects/flimnap/CMakeLists.txt
+++ b/projects/flimnap/CMakeLists.txt
@@ -19,8 +19,8 @@ set(CMAKE_C_FLAGS_DEBUG "-gdwarf-4 -fvar-tracking-assignments -Og")
 set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf-4 -fvar-tracking-assignments -Og")
 
 # Always use release flags for bicycle sources
-set_property(SOURCE ${BICYCLE_SOURCE}
-    APPEND_STRING PROPERTY COMPILE_FLAGS ${CMAKE_CXX_FLAGS_RELEASE})
+#set_property(SOURCE ${BICYCLE_SOURCE}
+#    APPEND_STRING PROPERTY COMPILE_FLAGS ${CMAKE_CXX_FLAGS_RELEASE})
 
 set(FLIMNAP_COMMON_SRC
     chconf.h
@@ -38,6 +38,9 @@ set(FLIMNAP_COMMON_SRC
     ${PHOBOS_SOURCE_DIR}/src/cobs.cc
     ${PROTOBUF_GENERATED_SOURCE}
     ${BICYCLE_SOURCE})
+
+# suppress warnings that protobuf fields do not match original declarations when using LTO
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-lto-type-mismatch")
 
 if(PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE)
 add_phobos_executable(flimnap_whipple ${FLIMNAP_COMMON_SRC})

--- a/projects/flimnap/CMakeLists.txt
+++ b/projects/flimnap/CMakeLists.txt
@@ -19,8 +19,8 @@ set(CMAKE_C_FLAGS_DEBUG "-gdwarf-4 -fvar-tracking-assignments -Og")
 set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf-4 -fvar-tracking-assignments -Og")
 
 # Always use release flags for bicycle sources
-#set_property(SOURCE ${BICYCLE_SOURCE}
-#    APPEND_STRING PROPERTY COMPILE_FLAGS ${CMAKE_CXX_FLAGS_RELEASE})
+set_property(SOURCE ${BICYCLE_SOURCE}
+    APPEND_STRING PROPERTY COMPILE_FLAGS " ${CMAKE_CXX_FLAGS_RELEASE}")
 
 set(FLIMNAP_COMMON_SRC
     chconf.h
@@ -41,6 +41,8 @@ set(FLIMNAP_COMMON_SRC
 
 # suppress warnings that protobuf fields do not match original declarations when using LTO
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-lto-type-mismatch")
+# suppress warnings from ChibiOS serial USB
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
 
 if(PHOBOS_BUILD_PROJECT_FLIMNAP_WHIPPLE)
 add_phobos_executable(flimnap_whipple ${FLIMNAP_COMMON_SRC})

--- a/projects/flimnap/CMakeLists.txt
+++ b/projects/flimnap/CMakeLists.txt
@@ -18,6 +18,10 @@ set_property(SOURCE
 set(CMAKE_C_FLAGS_DEBUG "-gdwarf-4 -fvar-tracking-assignments -Og")
 set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf-4 -fvar-tracking-assignments -Og")
 
+# Always use release flags for bicycle sources
+set_property(SOURCE ${BICYCLE_SOURCE}
+    APPEND_STRING PROPERTY COMPILE_FLAGS ${CMAKE_CXX_FLAGS_RELEASE})
+
 set(FLIMNAP_COMMON_SRC
     chconf.h
     halconf.h

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -220,6 +220,8 @@ int main(void) {
              0, 10).finished(),                 // enable steer control
             model_t::state_t::Zero(),           // reference state
             1);                                 // horizon length in iterations
+    // perform value iterations to reach controller steady state
+    controller.perform_value_iteration(2000);
 
     // Initialize HandlebarDynamic object to estimate torque due to handlebar inertia.
     // TODO: naming here is poor

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -204,7 +204,7 @@ int main(void) {
     // Initialize HandlebarDynamic object to estimate torque due to handlebar inertia.
     // TODO: naming here is poor
 #if !defined(FLIMNAP_ZERO_INPUT)
-    haptic::HandlebarDynamic handlebar_model(bicycle.model(), sa::UPPER_ASSEMBLY_INERTIA_VIRTUAL);
+    haptic::HandlebarDynamic handlebar_model(bicycle.model(), sa::UPPER_ASSEMBLY_INERTIA_PHYSICAL);
 #endif  // !defined(FLIMNAP_ZERO_INPUT)
 
     observer_initializer<observer_t> oi;

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -219,7 +219,7 @@ int main(void) {
              1, 0,                              // enable roll torque cost
              0, 0).finished(),                  // disable steer control
             model_t::state_t::Zero(),           // reference state
-            MS2ST(10)/looptime);                // horizon length in iterations
+            1);                                 // horizon length in iterations
 
     // Initialize HandlebarDynamic object to estimate torque due to handlebar inertia.
     // TODO: naming here is poor

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -210,14 +210,14 @@ int main(void) {
     // namely at low speed and at "large" roll angles.
     lqr_t controller(bicycle.model(),
             (lqr_t::state_cost_t() <<
-             0, 0, 0,   0,   0,                 // no yaw angle penalty
-             0, 1, 0,   0,   0,                 // roll angle penalty
-             0, 0, 0,   0,   0,                 // no steer angle penalty
-             0, 0, 0, 0.1,   0,                 // small roll rate penalty
-             0, 0, 0,   0, 0.1).finished(),     // small steer rate penalty
+             0,     0, 0,    0, 0,              // no yaw angle penalty
+             0, 10000, 0,    0, 0,              // large roll angle penalty
+             0,     0, 0,    0, 0,              // no steer angle penalty
+             0,     0, 0, 1000, 0,              // smaller roll rate penalty
+             0,     0, 0,    0, 0).finished(),  // no steer rate penalty
             (lqr_t::input_cost_t() <<
-             1, 0,                              // enable roll torque cost
-             0, 0).finished(),                  // disable steer control
+             0.001, 0,                          // enable roll torque cost
+                 0, 0).finished(),              // disable steer control
             model_t::state_t::Zero(),           // reference state
             1);                                 // horizon length in iterations
 

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -321,8 +321,10 @@ int main(void) {
                     msg->has_kalman = true;
                 }
                 if (assistive_torque) {
+                    msg.lqr.horizon_iterations = controller.horizon_iterations();
                     message::set_controller_gain_matrix<lqr_t>(&msg.lqr.lqr_gain, controller.K());
                     message::set_state_matrix(&msg.lqr.horizon_cost, controller.P());
+                    msg.lqr.has_horizon_iterations = true;
                     msg.lqr.has_lqr_gain = true;
                     msg.lqr.has_horizon_cost = true;
                     msg.has_lqr = true;

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -285,13 +285,15 @@ int main(void) {
         // simulate bicycle
         bicycle.set_v(v);
         // calculate assistive torque
-        const float roll_torque = ((bicycle.v() < assistive_velocity_limit) ||
-                                   (std::abs(model_t::get_state_element(bicycle.observer().state(),
-                                                                        model_t::state_index_t::roll_angle)) >
-                                             assistive_roll_angle_limit)) ?
-                                    model_t::get_input_element(controller.control_calculate(bicycle.observer().state()),
-                                        model_t::input_index_t::roll_torque) :
-                                    0.0f;
+        float roll_torque = 0.0f;
+        if ( (bicycle.v() < assistive_velocity_limit) ||
+             (std::abs(model_t::get_state_element(bicycle.observer().state(),
+                                                  model_t::state_index_t::roll_angle)) >
+                                             assistive_roll_angle_limit) ) {
+            const model_t::input_t u = controller.control_calculate(bicycle.observer().state());
+            roll_torque = model_t::get_input_element(u, model_t::input_index_t::roll_torque);
+            // TODO: logging here
+        }
         bicycle.update_dynamics(roll_torque, steer_torque, yaw_angle, steer_angle, rear_wheel_angle);
 
         // generate handlebar torque output

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -69,7 +69,7 @@ namespace {
     constexpr systime_t pose_loop_period = US2ST(8333); // update pose at 120 Hz
 
     // dynamics loop
-    constexpr systime_t dynamics_loop_period = MS2ST(1); // 1 ms -> 1 kHz
+    constexpr systime_t dynamics_loop_period = MS2ST(2); // 2 ms -> 500 Hz
 
     // Suspends the invoking thread until the system time arrives to the
     // specified value.

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -210,16 +210,16 @@ int main(void) {
     // namely at low speed and at "large" roll angles.
     lqr_t controller(bicycle.model(),
             (lqr_t::state_cost_t() <<
-             0, 0, 0,   0,   0,                                         // no yaw angle penalty
-             0, 1, 0,   0,   0,                                         // roll angle penalty
-             0, 0, 0,   0,   0,                                         // no steer angle penalty
-             0, 0, 0, 0.1,   0,                                         // small roll rate penalty
-             0, 0, 0,   0, 0.1).finished(),                             // small steer rate penalty
+             0, 0, 0,   0,   0,                 // no yaw angle penalty
+             0, 1, 0,   0,   0,                 // roll angle penalty
+             0, 0, 0,   0,   0,                 // no steer angle penalty
+             0, 0, 0, 0.1,   0,                 // small roll rate penalty
+             0, 0, 0,   0, 0.1).finished(),     // small steer rate penalty
             (lqr_t::input_cost_t() <<
-             1, 0,                                                      // enable roll torque cost
-             0, 0).finished(),                                          // disable steer control
-            model_t::state_t::Zero(),                                   // reference state
-            static_cast<model::real_t>(MS2ST(10))/CH_CFG_ST_FREQUENCY); // horizon length
+             1, 0,                              // enable roll torque cost
+             0, 0).finished(),                  // disable steer control
+            model_t::state_t::Zero(),           // reference state
+            MS2ST(10)/looptime);                // horizon length in iterations
 
     // Initialize HandlebarDynamic object to estimate torque due to handlebar inertia.
     // TODO: naming here is poor

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -288,7 +288,7 @@ int main(void) {
         const float roll_torque = ((bicycle.v() < assistive_velocity_limit) ||
                                    (std::abs(model_t::get_state_element(bicycle.observer().state(),
                                                                         model_t::state_index_t::roll_angle)) >
-                                             assistive_velocity_limit)) ?
+                                             assistive_roll_angle_limit)) ?
                                     model_t::get_input_element(controller.control_calculate(bicycle.observer().state()),
                                         model_t::input_index_t::roll_torque) :
                                     0.0f;

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -278,6 +278,9 @@ int main(void) {
             if (msg != nullptr) {
                 *msg = SimulationMessage_init_zero;
                 msg->timestamp = starttime;
+                msg->model.v = bicycle.v();
+                msg->model.has_v = true;
+                msg->has_model = true;
                 message::set_bicycle_input(&msg->input,
                         (model_t::input_t() << roll_torque, steer_torque).finished());
                 msg->has_input = true;

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -321,9 +321,10 @@ int main(void) {
                     msg->has_kalman = true;
                 }
                 if (assistive_torque) {
-                    //lqr_t::lqr_gain_t K = controller.K();
                     message::set_controller_gain_matrix<lqr_t>(&msg.lqr.lqr_gain, controller.K());
+                    message::set_state_matrix(&msg.lqr.horizon_cost, controller.P());
                     msg.lqr.has_lqr_gain = true;
+                    msg.lqr.has_horizon_cost = true;
                     msg.has_lqr = true;
                 }
                 message::set_simulation_actuators(msg, handlebar_velocity_dac);

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -210,14 +210,14 @@ int main(void) {
     // namely at low speed and at "large" roll angles.
     lqr_t controller(bicycle.model(),
             (lqr_t::state_cost_t() <<
-             0,     0, 0,    0, 0,              // no yaw angle penalty
-             0, 10000, 0,    0, 0,              // large roll angle penalty
-             0,     0, 0,    0, 0,              // no steer angle penalty
-             0,     0, 0, 1000, 0,              // smaller roll rate penalty
-             0,     0, 0,    0, 0).finished(),  // no steer rate penalty
+             0,    0, 0,    0, 0,              // no yaw angle penalty
+             0, 1000, 0,    0, 0,              // large roll angle penalty
+             0,    0, 0,    0, 0,              // no steer angle penalty
+             0,    0, 0,   10, 0,              // smaller roll rate penalty
+             0,    0, 0,    0, 0).finished(),  // no steer rate penalty
             (lqr_t::input_cost_t() <<
-             0.001, 0,                          // enable roll torque cost
-                 0, 0).finished(),              // disable steer control
+             1, 0,                          // enable roll torque cost
+             0, 0).finished(),              // disable steer control
             model_t::state_t::Zero(),           // reference state
             1);                                 // horizon length in iterations
 

--- a/projects/inc/messageutil.h
+++ b/projects/inc/messageutil.h
@@ -2,6 +2,7 @@
 #include "simulation.pb.h"
 #include "bicycle/bicycle.h"
 #include "kalman.h"
+#include "lqr.h"
 #include "simbicycle.h"
 
 namespace message {
@@ -18,7 +19,7 @@ namespace message {
     void set_bicycle_canonical(BicycleModelMessage* pb, const bicycle_t& b);
     void set_bicycle_discrete_time_state_space(BicycleModelMessage* pb, const bicycle_t& b);
 
-    /* functions for different observer variants */
+    // functions for different observer variants
     template <typename observer_t>
     typename std::enable_if<std::is_same<observer_t, typename observer::Kalman<typename observer_t::model_t>>::value, void>::type
     set_symmetric_output_matrix(SymmetricOutputMatrixMessage* pb, const typename observer_t::measurement_noise_covariance_t& m);
@@ -50,6 +51,13 @@ namespace message {
     template <typename observer_t>
     typename std::enable_if<!std::is_same<observer_t, typename observer::Kalman<typename observer_t::model_t>>::value, void>::type
     set_kalman_gain(BicycleKalmanMessage* pb, const observer_t& k);
+
+    // functions for controllers
+    template <typename controller_t>
+    void set_controller_gain_matrix(LqrGainMatrixMessage* pb, const typename controller_t::lqr_gain_t& m);
+
+    // TODO: Write setters for symmetric output matrix, symmetric input matrix that do not depend on controller or
+    // observer types
 
     void set_simulation_gitsha1(SimulationMessage* pb);
     void set_simulation_sensors(SimulationMessage* pb,
@@ -150,6 +158,12 @@ set_kalman_gain(BicycleKalmanMessage* pb, const observer_t& k) {
     // no-op
     (void)pb;
     (void)k;
+}
+
+template <typename controller_t>
+void set_controller_gain_matrix(LqrGainMatrixMessage* pb, const typename controller_t::lqr_gain_t& m) {
+    std::memcpy(pb->m, m.data(), sizeof(pb->m));
+    pb->m_count = sizeof(pb->m)/sizeof(pb->m[0]);
 }
 
 template <typename simbicycle_t>

--- a/projects/inc/saconfig.h
+++ b/projects/inc/saconfig.h
@@ -18,7 +18,7 @@ constexpr EncoderConfig RLS_ROLIN_ENC_CFG = {
 };
 
 constexpr EncoderConfig RLS_ROLIN_ENC_INDEX_CFG = {
-    .z = PAL_LINE(GPIOA, GPIOA_PIN2),
+    .z = PAL_LINE(GPIOA_BASE, GPIOA_PIN2),
     .counts_per_rev = 152000,
     .filter = EncoderConfig::filter_t::CAPTURE_64, // 64 / 42 MHz (TIM5 on APB1) = 1.52 us for valid edge
     .z_count = 18407

--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -44,8 +44,6 @@ class Bicycle {
         static constexpr real_t default_dt = 1.0/default_fs; // sample period, s
         static constexpr real_t default_v = 5.0; // forward speed, m/s
         static constexpr real_t v_quantization_resolution = 0.1; // m/s
-        static constexpr real_t roll_rate_limit = 1e10; // rad
-        static constexpr real_t steer_rate_limit = 1e10; // rad
         static constexpr real_t observer_prime_period = 3.0; // seconds
 
         Bicycle(real_t v = default_v, real_t dt = default_dt);

--- a/projects/proto/simulation.options
+++ b/projects/proto/simulation.options
@@ -12,7 +12,9 @@ ActuatorMessage.kollmorgen_command_velocity int_size:IS_16
 
 SymmetricStateMatrixMessage.m               max_count:15
 SymmetricOutputMatrixMessage.m              max_count:3
+SymmetricInputMatrixMessage.m               max_count:3
 KalmanGainMatrixMessage.m                   max_count:10
+LqrGainMatrixMessage.m                      max_count:10
 
 SecondOrderMatrixMessage.m                  max_count:4
 StateMatrixMessage.m                        max_count:25

--- a/projects/proto/simulation.proto
+++ b/projects/proto/simulation.proto
@@ -20,6 +20,8 @@ message SimulationMessage {
     optional TimingMessage timing = 11;
 
     optional float feedback_torque = 12;
+
+    optional BicycleLqrMessage lqr = 13;
 }
 
 message FirmwareVersion {
@@ -64,6 +66,11 @@ message SymmetricOutputMatrixMessage {
     repeated float m = 1;
 }
 
+// symmetric 2x2 matrix
+message SymmetricInputMatrixMessage {
+    repeated float m = 1;
+}
+
 // 5x2 matrix
 message KalmanGainMatrixMessage {
     repeated float m = 1;
@@ -75,6 +82,19 @@ message BicycleKalmanMessage {
     optional SymmetricStateMatrixMessage process_noise_covariance =        3;
     optional SymmetricOutputMatrixMessage measurement_noise_covariance =   4;
     optional KalmanGainMatrixMessage kalman_gain =                         5;
+}
+
+// 2x5 matrix
+message LqrGainMatrixMessage {
+    repeated float m = 1;
+}
+
+message BicycleLqrMessage {
+    optional BicycleStateMessage state_reference =      1;
+    optional uint32 horizon_iterations =                2;
+    optional SymmetricStateMatrixMessage state_cost =   3;
+    optional SymmetricInputMatrixMessage input_cost =   4;
+    optional LqrGainMatrixMessage lqr_gain =            5;
 }
 
 // 2x2 matrix

--- a/projects/proto/simulation.proto
+++ b/projects/proto/simulation.proto
@@ -95,6 +95,7 @@ message BicycleLqrMessage {
     optional SymmetricStateMatrixMessage state_cost =   3;
     optional SymmetricInputMatrixMessage input_cost =   4;
     optional LqrGainMatrixMessage lqr_gain =            5;
+    optional StateMatrixMessage horizon_cost =          6;
 }
 
 // 2x2 matrix

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -65,7 +65,7 @@ void Bicycle<Model, Observer>::update_dynamics(real_t roll_torque_input, real_t 
     //
     //  This could also be used to determine the wheel angles, as we assume
     //  no-slip conditions. However, we calculate the wheel angles during the
-    //  kinematic  update and solely from bicycle velocity.
+    //  kinematic update and solely from bicycle velocity.
     (void)rear_wheel_angle_measurement;
 
     m_input = input_t::Zero();
@@ -87,29 +87,6 @@ void Bicycle<Model, Observer>::update_dynamics(real_t roll_torque_input, real_t 
 
     if (!m_observer.state().allFinite()) {
         chSysHalt("");
-    }
-
-    { // limit allowed bicycle state
-        state_t x = m_observer.state();
-
-        auto limit_state_element = [&x](model::Bicycle::state_index_t index, real_t limit) {
-            const real_t value = model::Bicycle::get_state_element(x, index);
-            if (std::abs(value) > limit) {
-                model::Bicycle::set_state_element(x, index, std::copysign(limit, value));
-            }
-        };
-
-        real_t roll_angle = model_t::get_state_element(m_observer.state(),
-                model_t::state_index_t::roll_angle);
-        if (std::abs(roll_angle) > constants::pi) {
-            // state normalization limits angles to the range [-2*pi, 2*pi]
-            roll_angle += std::copysign(constants::two_pi, -1*roll_angle);
-        }
-
-        limit_state_element(model_t::state_index_t::roll_rate, roll_rate_limit);
-        limit_state_element(model_t::state_index_t::steer_rate, steer_rate_limit);
-
-        m_observer.set_state(x);
     }
 
     // Merge observer and model states

--- a/scripts/plot_sim.py
+++ b/scripts/plot_sim.py
@@ -28,7 +28,7 @@ def handlebar_inertia_torque(records, A):
     A_delta_dd = A[4, :]
     state = records.state
     steer_accel = np.dot(A_delta_dd, state.T)
-    inertia_torque = sa.UPPER_ASSEMBLY_INERTIA_VIRTUAL * steer_accel
+    inertia_torque = sa.UPPER_ASSEMBLY_INERTIA_PHYSICAL * steer_accel
     return inertia_torque, steer_accel
 
 


### PR DESCRIPTION
Use an LQR controller to generate an assistive virtual roll torque to
stabilize the virtual bicycle at low speed and at large roll angles.
Remove artificial bicycle state limits from sim::Bicycle class.

Fixes #169 