### PR TITLE
Disable low speed roll

### DIFF
--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -58,12 +58,6 @@ namespace {
                                               MS2ST(1), 3.0f);
     filter::MovingAverage<float, 5> velocity_filter;
 
-    // transmission
-    constexpr std::size_t VARINT_MAX_SIZE = 10;
-    std::array<uint8_t, SimulationMessage_size + VARINT_MAX_SIZE> encode_buffer;
-    std::array<uint8_t, cobs::max_encoded_length(SimulationMessage_size + VARINT_MAX_SIZE)> packet_buffer;
-    SimulationMessage msg;
-
     // pose calculation loop
     constexpr systime_t pose_loop_period = US2ST(8333); // update pose at 120 Hz
 

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -58,7 +58,11 @@ namespace {
                                               MS2ST(1), 3.0f);
     filter::MovingAverage<float, 5> velocity_filter;
 
-    constexpr float fixed_velocity = 5.0f;
+    // transmission
+    constexpr std::size_t VARINT_MAX_SIZE = 10;
+    std::array<uint8_t, SimulationMessage_size + VARINT_MAX_SIZE> encode_buffer;
+    std::array<uint8_t, cobs::max_encoded_length(SimulationMessage_size + VARINT_MAX_SIZE)> packet_buffer;
+    SimulationMessage msg;
 
     // pose calculation loop
     constexpr systime_t pose_loop_period = US2ST(8333); // update pose at 120 Hz
@@ -199,7 +203,7 @@ int main(void) {
 
     // Initialize bicycle. The initial velocity is important as we use it to prime
     // the Kalman gain matrix.
-    bicycle_t bicycle(fixed_velocity, static_cast<model::real_t>(dynamics_loop_period)/CH_CFG_ST_FREQUENCY);
+    bicycle_t bicycle(0.0f, static_cast<model::real_t>(dynamics_loop_period)/CH_CFG_ST_FREQUENCY);
 
     // Initialize HandlebarDynamic object to estimate torque due to handlebar inertia.
     // TODO: naming here is poor
@@ -264,7 +268,7 @@ int main(void) {
 #endif // defined(FLIMNAP_ZERO_INPUT)
 
         // simulate bicycle
-        bicycle.set_v(fixed_velocity);
+        bicycle.set_v(v);
         bicycle.update_dynamics(roll_torque, steer_torque, yaw_angle, steer_angle, rear_wheel_angle);
 
         // generate handlebar torque output

--- a/projects/flimnap/main.cc
+++ b/projects/flimnap/main.cc
@@ -266,8 +266,11 @@ int main(void) {
         bicycle.update_dynamics(roll_torque, steer_torque, yaw_angle, steer_angle, rear_wheel_angle);
 
         // generate handlebar torque output
-        const float desired_velocity = model_t::get_state_element(bicycle.observer().state(),
-                model_t::state_index_t::steer_rate);
+        const float desired_velocity = bicycle.v() > bicycle.v_critical ?
+            // calculate desired handlebar velocity
+            model_t::get_state_element(bicycle.observer().state(), model_t::state_index_t::steer_rate) :
+            // disabled below critical speed
+            0.0f;
         const dacsample_t handlebar_velocity_dac = set_handlebar_velocity(desired_velocity);
         chTMStopMeasurementX(&computation_time_measurement);
 

--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -44,8 +44,6 @@ class Bicycle {
         static constexpr real_t default_dt = 1.0/default_fs; // sample period, s
         static constexpr real_t default_v = 5.0; // forward speed, m/s
         static constexpr real_t v_quantization_resolution = 0.1; // m/s
-        static constexpr real_t roll_rate_limit = 1e10; // rad
-        static constexpr real_t steer_rate_limit = 1e10; // rad
         static constexpr real_t observer_prime_period = 3.0; // seconds
 
         Bicycle(real_t v = default_v, real_t dt = default_dt);

--- a/projects/inc/simbicycle.h
+++ b/projects/inc/simbicycle.h
@@ -45,6 +45,7 @@ class Bicycle {
         static constexpr real_t default_v = 5.0; // forward speed, m/s
         static constexpr real_t v_quantization_resolution = 0.1; // m/s
         static constexpr real_t observer_prime_period = 3.0; // seconds
+        static constexpr real_t v_critical = 1.0; // m/s, minimal speed to simulate full bicycle dynamics
 
         Bicycle(real_t v = default_v, real_t dt = default_dt);
 

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -89,29 +89,6 @@ void Bicycle<Model, Observer>::update_dynamics(real_t roll_torque_input, real_t 
         chSysHalt("");
     }
 
-    { // limit allowed bicycle state
-        state_t x = m_observer.state();
-
-        auto limit_state_element = [&x](model::Bicycle::state_index_t index, real_t limit) {
-            const real_t value = model::Bicycle::get_state_element(x, index);
-            if (std::abs(value) > limit) {
-                model::Bicycle::set_state_element(x, index, std::copysign(limit, value));
-            }
-        };
-
-        real_t roll_angle = model_t::get_state_element(m_observer.state(),
-                model_t::state_index_t::roll_angle);
-        if (std::abs(roll_angle) > constants::pi) {
-            // state normalization limits angles to the range [-2*pi, 2*pi]
-            roll_angle += std::copysign(constants::two_pi, -1*roll_angle);
-        }
-
-        limit_state_element(model_t::state_index_t::roll_rate, roll_rate_limit);
-        limit_state_element(model_t::state_index_t::steer_rate, steer_rate_limit);
-
-        m_observer.set_state(x);
-    }
-
     // Merge observer and model states
     //
     // We simply copy the observer state estimate to the full state vector

--- a/scripts/load_sim.py
+++ b/scripts/load_sim.py
@@ -46,6 +46,11 @@ def load_messages(filename):
 
 def get_records_from_messages(messages):
     _, dtype = get_simulation_types()
+
+    # Discard pose messages as we are only interested in simulation messages
+    # TODO: Return pose messages
+    messages = [msg for msg in messages if msg.timestamp != 0]
+
     records = np.recarray((len(messages),), dtype)
     for rec, msg in zip(records, messages):
         pb.set_record_from_message(rec, msg)
@@ -76,4 +81,5 @@ if __name__ == '__main__':
     messages = load_messages(sys.argv[1])
     print('got {} message(s)'.format(len(messages)))
     records = get_records_from_messages(messages)
+    print('created {} record(s)'.format(len(records)))
     t = get_time_vector(records)


### PR DESCRIPTION
Set roll angle and roll rate to zero below a critical speed of 1 m/s.

Fixes #169

This PR is dependent on the following PRs: #220, #221 
~~This cannot be tested until #208 is fixed.~~