### PR TITLE
Remove Oracle observer

### DIFF
--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -73,11 +73,11 @@ void Bicycle<Model, Observer>::set_dt(real_t dt)  {
 template <typename Model, typename Observer>
 OBSERVER_FUNCTION(void) Bicycle<Model, Observer>::reset() {
     m_observer.reset();
-    //TODO: reset full state?
+    m_full_state = full_state_t::Zero();
 }
 template <typename Model, typename Observer>
 NULL_OBSERVER_FUNCTION(void) Bicycle<Model, Observer>::reset() {
-    //TODO: reset full state?
+    m_full_state = full_state_t::Zero();
 }
 
 template <typename Model, typename Observer>
@@ -266,7 +266,7 @@ OBSERVER_FUNCTION(typename BICYCLE_TYPE::full_state_t) Bicycle<Model, Observer>:
     m_observer.update_state(m_input, m_measurement);
 
     if (!m_observer.state().allFinite()) {
-        chSysHalt("");
+        chSysHalt("state elements with non finite values");
     }
 
     { // limit allowed bicycle state
@@ -283,6 +283,7 @@ OBSERVER_FUNCTION(typename BICYCLE_TYPE::full_state_t) Bicycle<Model, Observer>:
                 model_t::state_index_t::roll_angle);
         if (std::abs(roll_angle) > constants::pi) {
             // state normalization limits angles to the range [-2*pi, 2*pi]
+            // and here we constrain it further to [-pi, pi]
             roll_angle += std::copysign(constants::two_pi, -1*roll_angle);
         }
 
@@ -299,8 +300,6 @@ OBSERVER_FUNCTION(typename BICYCLE_TYPE::full_state_t) Bicycle<Model, Observer>:
     // convergence of the observer estimate should keep it low.
     // Also, we have no way to correct auxiliary states as there are no sensors
     // to measure them and that's because they are _purely_ virtual.
-    //
-    // TODO: improve this
     return model_t::make_full_state(model_t::get_auxiliary_state_part(state_full),
                                     m_observer.state());
 }

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -284,6 +284,9 @@ OBSERVER_FUNCTION(typename BICYCLE_TYPE::full_state_t) Bicycle<Model, Observer>:
         if (std::abs(roll_angle) > constants::pi) {
             // state normalization limits angles to the range [-2*pi, 2*pi]
             // and here we constrain it further to [-pi, pi]
+            chDbgAssert((roll_angle <= constants::two_pi) &&
+                        (roll_angle >= -constants::two_pi),
+                        "roll angle not model normalized");
             roll_angle += std::copysign(constants::two_pi, -1*roll_angle);
         }
 

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -279,15 +279,15 @@ OBSERVER_FUNCTION(typename BICYCLE_TYPE::full_state_t) Bicycle<Model, Observer>:
             }
         };
 
-        real_t roll_angle = model_t::get_state_element(m_observer.state(),
-                model_t::state_index_t::roll_angle);
+        const real_t roll_angle = model_t::get_state_element(x, model_t::state_index_t::roll_angle);
         if (std::abs(roll_angle) > constants::pi) {
             // state normalization limits angles to the range [-2*pi, 2*pi]
             // and here we constrain it further to [-pi, pi]
             chDbgAssert((roll_angle <= constants::two_pi) &&
                         (roll_angle >= -constants::two_pi),
                         "roll angle not model normalized");
-            roll_angle += std::copysign(constants::two_pi, -1*roll_angle);
+            model_t::set_state_element(x, model_t::state_index_t::roll_angle,
+                    roll_angle + std::copysign(constants::two_pi, -1*roll_angle));
         }
 
         limit_state_element(model_t::state_index_t::roll_rate, roll_rate_limit);

--- a/projects/src/simbicycle.hh
+++ b/projects/src/simbicycle.hh
@@ -2,7 +2,6 @@
 #include <type_traits>
 #include <boost/math/special_functions/round.hpp>
 #include "bicycle/kinematic.h"
-#include "oracle.h"
 #include "kalman.h"
 /*
  * Member function definitions of sim::Bicycle template class.
@@ -11,20 +10,44 @@
 
 namespace sim {
 
-template <typename Model, typename Observer>
-Bicycle<Model, Observer>::Bicycle(real_t v, real_t dt) :
+#define OBSERVER_FUNCTION(return_type) \
+    template <typename T> \
+    typename std::enable_if<std::is_base_of<observer::ObserverBase, T>::value, return_type>::type
+#define NULL_OBSERVER_FUNCTION(return_type) \
+    template <typename T> \
+    typename std::enable_if<!std::is_base_of<observer::ObserverBase, T>::value, return_type>::type
+#define BICYCLE_TYPE Bicycle<Model, Observer>
+
+template <typename Model, typename Observer> template <typename T>
+Bicycle<Model, Observer>::Bicycle(typename std::enable_if<std::is_base_of<observer::ObserverBase, T>::value, real_t>::type v, real_t dt) :
 m_model(v, dt),
 m_observer(m_model),
 m_full_state(full_state_t::Zero()),
 m_pose(BicyclePoseMessage_init_zero),
-m_input(input_t::Zero()) {
+m_input(input_t::Zero()),
+m_measurement(measurement_t::Zero()) {
     // Note: User must initialize Kalman matrices in application.
-    // TODO: Do this automatically with default values?
     chBSemObjectInit(&m_state_sem, false); // initialize to not taken
 
 static_assert((!std::is_same<Model, model::BicycleKinematic>::value) ||
-              std::is_same<Observer, observer::Oracle<model::BicycleKinematic>>::value,
-              "Only Oracle observer type can be used with BicycleKinematic model type.");
+              std::is_same<Observer, std::nullptr_t>::value,
+              "Only std::nullptr_t observer type can be used with BicycleKinematic model type.");
+}
+
+template <typename Model, typename Observer> template <typename T>
+Bicycle<Model, Observer>::Bicycle(typename std::enable_if<!std::is_base_of<observer::ObserverBase, T>::value, real_t>::type v, real_t dt) :
+m_model(v, dt),
+m_observer(nullptr),
+m_full_state(full_state_t::Zero()),
+m_pose(BicyclePoseMessage_init_zero),
+m_input(input_t::Zero()),
+m_measurement(measurement_t::Zero()) {
+    // Note: User must initialize Kalman matrices in application.
+    chBSemObjectInit(&m_state_sem, false); // initialize to not taken
+
+static_assert((!std::is_same<Model, model::BicycleKinematic>::value) ||
+              std::is_same<Observer, std::nullptr_t>::value,
+              "Only std::nullptr_t observer type can be used with BicycleKinematic model type.");
 }
 
 template <typename Model, typename Observer>
@@ -48,8 +71,13 @@ void Bicycle<Model, Observer>::set_dt(real_t dt)  {
 }
 
 template <typename Model, typename Observer>
-void Bicycle<Model, Observer>::reset() {
+OBSERVER_FUNCTION(void) Bicycle<Model, Observer>::reset() {
     m_observer.reset();
+    //TODO: reset full state?
+}
+template <typename Model, typename Observer>
+NULL_OBSERVER_FUNCTION(void) Bicycle<Model, Observer>::reset() {
+    //TODO: reset full state?
 }
 
 template <typename Model, typename Observer>
@@ -69,75 +97,34 @@ void Bicycle<Model, Observer>::update_dynamics(real_t roll_torque_input, real_t 
     (void)rear_wheel_angle_measurement;
 
     m_input = input_t::Zero();
-    measurement_t measurement = measurement_t::Zero();
-
     model_t::set_input_element(m_input, model_t::input_index_t::roll_torque, roll_torque_input);
     model_t::set_input_element(m_input, model_t::input_index_t::steer_torque, steer_torque_input);
-    model_t::set_output_element(measurement, model_t::output_index_t::yaw_angle, yaw_angle_measurement);
-    model_t::set_output_element(measurement, model_t::output_index_t::steer_angle, steer_angle_measurement);
+    m_measurement = measurement_t::Zero();
+    model_t::set_output_element(m_measurement, model_t::output_index_t::yaw_angle, yaw_angle_measurement);
+    model_t::set_output_element(m_measurement, model_t::output_index_t::steer_angle, steer_angle_measurement);
 
-    // The auxiliary states _must_ also be integrated at the same time as the
-    // dynamic state. After the observer update, we "merge" dynamic states together.
+    // do full state update which is observer specific
     chBSemWait(&m_state_sem);
     full_state_t full_state_copy = m_full_state;
     chBSemSignal(&m_state_sem);
-    full_state_t full_state_next = m_model.integrate_full_state(
-            full_state_copy, m_input, m_model.dt(), measurement);
-    m_observer.update_state(m_input, measurement);
 
-    if (!m_observer.state().allFinite()) {
-        chSysHalt("");
-    }
+    full_state_t full_state_next = do_full_state_update(full_state_copy);
 
-    { // limit allowed bicycle state
-        state_t x = m_observer.state();
-
-        auto limit_state_element = [&x](model::Bicycle::state_index_t index, real_t limit) {
-            const real_t value = model::Bicycle::get_state_element(x, index);
-            if (std::abs(value) > limit) {
-                model::Bicycle::set_state_element(x, index, std::copysign(limit, value));
-            }
-        };
-
-        real_t roll_angle = model_t::get_state_element(m_observer.state(),
-                model_t::state_index_t::roll_angle);
-        if (std::abs(roll_angle) > constants::pi) {
-            // state normalization limits angles to the range [-2*pi, 2*pi]
-            roll_angle += std::copysign(constants::two_pi, -1*roll_angle);
-        }
-
-        limit_state_element(model_t::state_index_t::roll_rate, roll_rate_limit);
-        limit_state_element(model_t::state_index_t::steer_rate, steer_rate_limit);
-
-        m_observer.set_state(x);
-    }
-
-    // Merge observer and model states
-    //
-    // We simply copy the observer state estimate to the full state vector
-    // this may result in accumulated error in the auxiliary states but
-    // convergence of the observer estimate should keep it low.
-    // Also, we have no way to correct auxiliary states as there are no sensors
-    // to measure them and that's because they are _purely_ virtual.
-    //
-    // TODO: improve this
     chBSemWait(&m_state_sem);
-    m_full_state = model_t::make_full_state(
-            model_t::get_auxiliary_state_part(full_state_next),
-            m_observer.state());
+    m_full_state = full_state_next;
     chBSemSignal(&m_state_sem);
 }
 
 template <typename Model, typename Observer>
 void Bicycle<Model, Observer>::update_kinematics() {
     chBSemWait(&m_state_sem);
-    full_state_t x = m_full_state;
+    full_state_t full_state_copy = m_full_state;
     chBSemSignal(&m_state_sem);
 
     // solve for pitch as this does not get integrated
-    const real_t roll = model_t::get_full_state_element(x, full_state_index_t::roll_angle);
-    const real_t steer = model_t::get_full_state_element(x, full_state_index_t::steer_angle);
-    real_t pitch = model_t::get_full_state_element(x, full_state_index_t::pitch_angle);
+    const real_t roll = model_t::get_full_state_element(full_state_copy, full_state_index_t::roll_angle);
+    const real_t steer = model_t::get_full_state_element(full_state_copy, full_state_index_t::steer_angle);
+    real_t pitch = model_t::get_full_state_element(full_state_copy, full_state_index_t::pitch_angle);
     pitch = m_model.solve_constraint_pitch(roll, steer, pitch);
 
     // update full state with newest computed pitch angle
@@ -146,34 +133,37 @@ void Bicycle<Model, Observer>::update_kinematics() {
 
     // mod rear wheel angle so it does not grow beyond all bounds
     model_t::set_full_state_element(m_full_state, full_state_index_t::rear_wheel_angle,
-            std::fmod(model_t::get_full_state_element(x, full_state_index_t::rear_wheel_angle),
+            std::fmod(model_t::get_full_state_element(full_state_copy, full_state_index_t::rear_wheel_angle),
                       constants::two_pi)),
     chBSemSignal(&m_state_sem);
 
     m_pose.timestamp = chVTGetSystemTime();
-    m_pose.x = model_t::get_full_state_element(x, full_state_index_t::x);
-    m_pose.y = model_t::get_full_state_element(x, full_state_index_t::y);
-    m_pose.rear_wheel = model_t::get_full_state_element(x, full_state_index_t::rear_wheel_angle);
+    m_pose.x = model_t::get_full_state_element(full_state_copy, full_state_index_t::x);
+    m_pose.y = model_t::get_full_state_element(full_state_copy, full_state_index_t::y);
+    m_pose.rear_wheel = model_t::get_full_state_element(full_state_copy, full_state_index_t::rear_wheel_angle);
     m_pose.pitch = pitch;
-    m_pose.yaw = model_t::get_full_state_element(x, full_state_index_t::yaw_angle);
+    m_pose.yaw = model_t::get_full_state_element(full_state_copy, full_state_index_t::yaw_angle);
     m_pose.roll = roll;
     m_pose.steer = steer;
 }
 
 template <typename Model, typename Observer>
-void Bicycle<Model, Observer>::prime_observer() {
-    if (std::is_same<Observer, typename observer::Kalman<Model>>::value) {
-        // define a non-zero initial state, this is selected arbitrarily for now
-        state_t x = state_t::Zero();
-        model::Bicycle::set_state_element(x, model_t::state_index_t::steer_angle, 0.1f); // in radians
+OBSERVER_FUNCTION(void) Bicycle<Model, Observer>::prime_observer() {
+    // define a non-zero initial state, this is selected arbitrarily for now
+    state_t x = state_t::Zero();
+    model::Bicycle::set_state_element(x, model_t::state_index_t::steer_angle, 0.1f); // in radians
 
-        float t = 0;
-        while (t < observer_prime_period) {
-            x = m_model.update_state(x);
-            m_observer.update_state(input_t::Zero(), m_model.calculate_output(x));
-            t += m_model.dt();
-        }
+    static constexpr real_t observer_prime_period = 3.0; // seconds
+    real_t t = 0;
+    while (t < observer_prime_period) {
+        x = m_model.update_state(x);
+        m_observer.update_state(input_t::Zero(), m_model.calculate_output(x));
+        t += m_model.dt();
     }
+}
+template <typename Model, typename Observer>
+NULL_OBSERVER_FUNCTION(void) Bicycle<Model, Observer>::prime_observer() {
+        // do nothing
 }
 
 template <typename Model, typename Observer>
@@ -264,6 +254,61 @@ model::real_t Bicycle<Model, Observer>::dt() const {
 template <typename Model, typename Observer>
 const typename Bicycle<Model, Observer>::full_state_t& Bicycle<Model, Observer>::full_state() const {
     return m_full_state;
+}
+
+template <typename Model, typename Observer>
+OBSERVER_FUNCTION(typename BICYCLE_TYPE::full_state_t) Bicycle<Model, Observer>::do_full_state_update(const full_state_t& full_state) {
+    // The auxiliary states _must_ also be integrated at the same time as the
+    // dynamic state. After the observer update, we "merge" dynamic states together.
+    full_state_t state_full = m_model.integrate_full_state(
+            full_state, m_input, m_model.dt(), m_measurement);
+
+    m_observer.update_state(m_input, m_measurement);
+
+    if (!m_observer.state().allFinite()) {
+        chSysHalt("");
+    }
+
+    { // limit allowed bicycle state
+        state_t x = m_observer.state();
+
+        auto limit_state_element = [&x](model::Bicycle::state_index_t index, real_t limit) {
+            const real_t value = model::Bicycle::get_state_element(x, index);
+            if (std::abs(value) > limit) {
+                model::Bicycle::set_state_element(x, index, std::copysign(limit, value));
+            }
+        };
+
+        real_t roll_angle = model_t::get_state_element(m_observer.state(),
+                model_t::state_index_t::roll_angle);
+        if (std::abs(roll_angle) > constants::pi) {
+            // state normalization limits angles to the range [-2*pi, 2*pi]
+            roll_angle += std::copysign(constants::two_pi, -1*roll_angle);
+        }
+
+        limit_state_element(model_t::state_index_t::roll_rate, roll_rate_limit);
+        limit_state_element(model_t::state_index_t::steer_rate, steer_rate_limit);
+
+        m_observer.set_state(x);
+    }
+
+    // Merge observer and model states
+    //
+    // We simply copy the observer state estimate to the full state vector
+    // this may result in accumulated error in the auxiliary states but
+    // convergence of the observer estimate should keep it low.
+    // Also, we have no way to correct auxiliary states as there are no sensors
+    // to measure them and that's because they are _purely_ virtual.
+    //
+    // TODO: improve this
+    return model_t::make_full_state(model_t::get_auxiliary_state_part(state_full),
+                                    m_observer.state());
+}
+
+template <typename Model, typename Observer>
+NULL_OBSERVER_FUNCTION(typename BICYCLE_TYPE::full_state_t) Bicycle<Model, Observer>::do_full_state_update(const full_state_t& full_state) {
+    // REMOVE ME: No limiting is done but that is removed in a different commit
+    return m_model.integrate_full_state(full_state, m_input, m_model.dt(), m_measurement);
 }
 
 } // namespace sim


### PR DESCRIPTION
The Oracle observer doesn't do anything so we shouldn't use it.

Fixes #231 